### PR TITLE
fix(specify): Worktree内でのSPEC作成をサポート

### DIFF
--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -62,7 +62,18 @@ find_repo_root() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if git rev-parse --show-toplevel >/dev/null 2>&1; then
-    REPO_ROOT=$(git rev-parse --show-toplevel)
+    # Check if we're in a worktree
+    if git rev-parse --git-dir 2>/dev/null | grep -q "\.git/worktrees"; then
+        # In a worktree: use the worktree root (find from current working directory)
+        REPO_ROOT="$(find_repo_root "$PWD")"
+        if [ -z "$REPO_ROOT" ]; then
+            # Fallback to PWD if marker not found
+            REPO_ROOT="$PWD"
+        fi
+    else
+        # In main repository: use standard git root
+        REPO_ROOT=$(git rev-parse --show-toplevel)
+    fi
     HAS_GIT=true
 else
     REPO_ROOT="$(find_repo_root "$SCRIPT_DIR")"


### PR DESCRIPTION
## 概要

`create-new-feature.sh`スクリプトがWorktree内で実行された場合、mainリポジトリルートではなくWorktreeルートを使用するように修正しました。

## 問題

従来、Worktree内で`/speckit.specify`を実行すると、`git rev-parse --show-toplevel`がmainリポジトリのルートを返すため、SPECディレクトリがmainブランチ側の`specs/`に作成されてしまっていました。

## 解決策

1. `git rev-parse --git-dir`でWorktree内かどうかを判定
2. Worktree内なら`find_repo_root`を使用して現在のディレクトリから探索
3. mainブランチなら従来通り`git rev-parse --show-toplevel`を使用

## 変更内容

- `.specify/scripts/bash/create-new-feature.sh`のREPO_ROOT解決ロジックを修正
- Worktree対応のブランチ判定を追加

## テスト

- [ ] Worktree内で`/speckit.specify`を実行し、Worktree内の`specs/`にSPECが作成されることを確認
- [ ] mainブランチで`/speckit.specify`を実行し、従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **修正**
  * Git ワークツリー環境におけるリポジトリルート検出の信頼性を向上。フォールバック処理を強化し、リポジトリルートが特定できない場合のエラーハンドリングを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->