### PR TITLE
fix(release): remove GH_TOKEN to match unity-mcp-server

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Create release branch
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           RELEASE_BRANCH="release/v${VERSION}"
 


### PR DESCRIPTION
## Summary

create-release.ymlのGH_TOKEN環境変数を削除し、unity-mcp-serverのワークフローと完全に一致させました。

## 問題

PR #60でGH_TOKEN環境変数を追加しましたが、unity-mcp-serverの動作する構成にはこの環境変数がありません。

## 修正内容

- create-release.ymlの「Create release branch」ステップからGH_TOKEN環境変数を削除
- Checkout actionのtokenパラメータのみで認証を行う（unity-mcp-serverと同じ構成）

**重要**: GH_TOKEN環境変数はgh CLIコマンド用であり、gitコマンドには影響しません。Checkout actionのtokenパラメータが自動的にgit操作の認証に使用されます。

## テスト計画

1. このPRをマージ
2. 既存のrelease/v1.1.0ブランチを削除
3. create-release.ymlを再実行
4. release.ymlが自動的にトリガーされることを確認
5. semantic-releaseが実行され、タグ・リリースが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * リリース作成プロセスの認証メカニズムを簡素化しました。既定の認証設定に切り替えることで、リリースワークフローの信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->