### PR TITLE
fix(release): explicitly use PERSONAL_ACCESS_TOKEN for git push

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -84,6 +84,7 @@ jobs:
       - name: Create release branch
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
           RELEASE_BRANCH="release/v${VERSION}"
 
@@ -93,6 +94,9 @@ jobs:
           fi
 
           git checkout -b "$RELEASE_BRANCH"
+
+          # Use PERSONAL_ACCESS_TOKEN explicitly for push to trigger workflows
+          git remote set-url origin "https://x-access-token:${PERSONAL_ACCESS_TOKEN}@github.com/akiojin/ollama-coordinator.git"
           git push --no-verify origin "$RELEASE_BRANCH"
 
           echo "✓ Created and pushed $RELEASE_BRANCH"


### PR DESCRIPTION
## Summary

git pushでPERSONAL_ACCESS_TOKENを明示的に使用するように修正しました。

## 問題

- PERSONAL_ACCESS_TOKENは正しく設定されている（repo, workflowスコープあり）
- しかし、release.ymlワークフローが自動的にトリガーされない
- Checkout actionのtokenパラメータだけでは、git pushでそのトークンが使われていない

## 修正内容

git pushの前に、PERSONAL_ACCESS_TOKENを埋め込んだURLに変更：

```bash
git remote set-url origin "https://x-access-token:${PERSONAL_ACCESS_TOKEN}@github.com/akiojin/ollama-coordinator.git"
git push --no-verify origin "$RELEASE_BRANCH"
```

これにより、git pushが確実にPERSONAL_ACCESS_TOKENを使用し、release.ymlワークフローが正しくトリガーされるようになります。

## テスト計画

1. このPRをマージ
2. release/v1.1.0ブランチを削除
3. create-release.ymlを実行
4. release.ymlが自動的にトリガーされることを確認 ← これが成功すれば問題解決
5. semantic-releaseが実行され、タグ・リリースが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このリリースには、ユーザーに直接影響する変更は含まれていません。

* **Chores**
  * リリースワークフローの認証メカニズムを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->