### PR TITLE
fix(release): revert to simple form matching unity-mcp-server

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -64,27 +64,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Verify token configuration
-        env:
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Checking token configuration..."
-          if [ -n "$PERSONAL_ACCESS_TOKEN" ]; then
-            echo "✓ PERSONAL_ACCESS_TOKEN is set (length: ${#PERSONAL_ACCESS_TOKEN})"
-            # Get token info using GitHub API
-            TOKEN_TYPE=$(curl -s -H "Authorization: token $PERSONAL_ACCESS_TOKEN" \
-              https://api.github.com/user \
-              -I | grep -i "x-oauth-scopes" || echo "Failed to check scopes")
-            echo "Token scopes: $TOKEN_TYPE"
-          else
-            echo "❌ PERSONAL_ACCESS_TOKEN is NOT set - will use GITHUB_TOKEN"
-          fi
-
       - name: Create release branch
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
           RELEASE_BRANCH="release/v${VERSION}"
 
@@ -94,9 +76,6 @@ jobs:
           fi
 
           git checkout -b "$RELEASE_BRANCH"
-
-          # Use PERSONAL_ACCESS_TOKEN explicitly for push to trigger workflows
-          git remote set-url origin "https://x-access-token:${PERSONAL_ACCESS_TOKEN}@github.com/akiojin/ollama-coordinator.git"
           git push --no-verify origin "$RELEASE_BRANCH"
 
           echo "✓ Created and pushed $RELEASE_BRANCH"


### PR DESCRIPTION
## Summary

全ての追加変更を削除して、unity-mcp-server v2.35.1と完全に同じシンプルな形に戻しました。

## 変更内容

削除した要素：
- トークン検証ステップ
- `git remote set-url` による明示的なトークン埋め込み
- Create release branchステップからのPERSONAL_ACCESS_TOKEN環境変数

## 理由

unity-mcp-server v2.35.1では、これらの追加要素なしで正常に動作していました。追加した変更が、実際には問題を悪化させていた可能性があります。

Checkout actionのtokenパラメータだけに依存する、最もシンプルな形に戻すことで、unity-mcp-serverと完全に同じ動作を期待します。

## テスト計画

1. このPRをマージ
2. release/v1.1.0ブランチを削除
3. create-release.ymlを実行
4. release.ymlが自動的にトリガーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の改善**
  * GitHub Actionsワークフローの内部設定を簡素化しました。認証プロセスを最適化し、ワークフローの実行をより効率的にしました。

---

*ユーザーに直接影響する変更はありません。このリリースは内部インフラストラクチャの改善です。*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->