### PR TITLE
fix(release): explicitly trigger release.yml via gh workflow run

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Create release branch
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           RELEASE_BRANCH="release/v${VERSION}"
 
@@ -79,6 +80,14 @@ jobs:
           git push --no-verify origin "$RELEASE_BRANCH"
 
           echo "✓ Created and pushed $RELEASE_BRANCH"
+          echo ""
+
+          # Trigger release.yml workflow explicitly
+          # GitHub Actions from Actions don't trigger other workflows automatically
+          echo "Triggering release.yml workflow..."
+          gh workflow run release.yml --ref "$RELEASE_BRANCH"
+
+          echo "✓ Release workflow triggered"
           echo ""
           echo "Next steps:"
           echo "1. Wait for release.yml to complete"


### PR DESCRIPTION
## Summary

GitHub Actionsの制限を回避するため、release.ymlを明示的にトリガーする修正を追加しました。

## 問題の本質

GitHub Actionsからのpushは、PERSONAL_ACCESS_TOKENを使用しても、**Workflow recursion防止機能**により他のワークフローを自動的にトリガーしません。

これはGitHubのセキュリティ仕様であり、無限ループを防ぐための制限です。

## 解決方法

ブランチ作成後、`gh workflow run`コマンドでrelease.ymlを明示的にトリガー：

```yaml
- name: Create release branch
  env:
    VERSION: ${{ steps.version.outputs.version }}
    GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
  run: |
    RELEASE_BRANCH="release/v${VERSION}"
    git checkout -b "$RELEASE_BRANCH"
    git push --no-verify origin "$RELEASE_BRANCH"

    # Explicitly trigger release.yml
    gh workflow run release.yml --ref "$RELEASE_BRANCH"
```

## テスト計画

1. このPRをマージ
2. release/v1.1.0ブランチを削除
3. create-release.ymlを実行
4. release.ymlが明示的にトリガーされることを確認 ← これで成功するはず
5. semantic-releaseが実行され、タグ・リリースが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * リリース処理の自動化が改善されました。認証トークンの処理が最適化され、リリースワークフロー実行の明示的なトリガー機能が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->