### PR TITLE
fix(release): remove ANSI color codes before version extraction

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -44,7 +44,9 @@ jobs:
           OUTPUT=$(pnpm exec semantic-release --dry-run --branches develop 2>&1)
           echo "$OUTPUT"
 
-          VERSION=$(echo "$OUTPUT" | grep -oP 'The next release version is \K[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          # Remove ANSI color codes before extracting version
+          CLEAN_OUTPUT=$(echo "$OUTPUT" | sed 's/\x1b\[[0-9;]*m//g')
+          VERSION=$(echo "$CLEAN_OUTPUT" | grep -oP 'The next release version is \K[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 
           if [ -z "$VERSION" ]; then
             echo "Error: Could not determine next version"


### PR DESCRIPTION
## Summary

semantic-releaseの出力からバージョン番号を抽出できなかった問題を修正しました。

## 問題

semantic-releaseの出力にANSIカラーコードが含まれているため、grepでのパターンマッチングが失敗していました：

```
[5:07:01 PM] [semantic-release] › ℹ  The next release version is 1.1.0
```

この出力にはANSIエスケープコード（`\x1b[0-9;]*m`）が含まれており、単純な grep では一致しませんでした。

## 修正内容

ANSIエスケープコードを削除してからバージョンを抽出：

```bash
# Remove ANSI color codes before extracting version
CLEAN_OUTPUT=$(echo "$OUTPUT" | sed 's/\x1b\[[0-9;]*m//g')
VERSION=$(echo "$CLEAN_OUTPUT" | grep -oP 'The next release version is \K[0-9]+\.[0-9]+\.[0-9]+' | head -1)
```

## テスト計画

1. このPRをマージ
2. create-release.ymlを実行
3. バージョン番号が正しく抽出されることを確認
4. release/v1.1.0ブランチが作成されることを確認
5. release.ymlが明示的にトリガーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * リリースワークフローの出力処理を改善し、より正確なバージョン検出の処理を実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->