### PR TITLE
fix(release): unity-mcp-serverと完全に同じリリースフローに統一

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -69,7 +69,6 @@ jobs:
       - name: Create release branch
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           RELEASE_BRANCH="release/v${VERSION}"
 
@@ -82,19 +81,7 @@ jobs:
           git push --no-verify origin "$RELEASE_BRANCH"
 
           echo "✓ Created and pushed $RELEASE_BRANCH"
-          echo ""
-
-          # Trigger release.yml workflow explicitly
-          # GitHub Actions from Actions don't trigger other workflows automatically
-          echo "Waiting for GitHub to recognize the new branch..."
-          sleep 10
-
-          echo "Triggering release.yml workflow..."
-          # Use GitHub REST API directly to ensure correct ref
-          gh api repos/akiojin/ollama-coordinator/actions/workflows/release.yml/dispatches \
-            -f ref="$RELEASE_BRANCH"
-
-          echo "✓ Release workflow triggered"
+          echo "Semantic-release will now run on this branch automatically."
           echo ""
           echo "Next steps:"
           echo "1. Wait for release.yml to complete"


### PR DESCRIPTION
## Summary

unity-mcp-serverと完全に同じリリースフローに統一しました。

## 変更内容

以下の要素を削除して、unity-mcp-serverのワークフローと完全に一致させました：

1. **GH_TOKEN環境変数の削除**
   - Create release branchステップから削除
   - Checkout stepのtokenパラメータのみを使用

2. **workflow_dispatch明示的トリガーの削除**
   - `gh api` REST API呼び出しを削除
   - 10秒待機処理を削除
   - PERSONAL_ACCESS_TOKENによるpushのみに依存

## 理由

unity-mcp-server v2.35.1では、これらの追加要素なしで正常に動作していました。
GH_TOKEN環境変数の設定が、PERSONAL_ACCESS_TOKENによるpushの動作に影響を与えていた可能性があります。

PERSONAL_ACCESS_TOKENを使用したpushは、GitHub Actionsの制限（Workflow recursion prevention）を回避し、
他のワークフローを自動的にトリガーするはずです。

## テスト計画

1. このPRをマージ
2. release/v1.1.0ブランチを削除
3. create-release.ymlを実行
4. release.ymlが自動的にトリガーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア**
  * リリースワークフローのプロセスを簡素化しました。セマンティックリリースは対象ブランチで自動的に実行されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->