### PR TITLE
fix(release): yaml syntax error in merge commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,10 +106,9 @@ jobs:
 
           echo "Merging $RELEASE_BRANCH to main (version: $VERSION)..."
           git fetch origin "$RELEASE_BRANCH"
-          git merge "origin/$RELEASE_BRANCH" --no-ff -m "chore(release): merge v${VERSION} to main
-
-Automated merge of release branch for version ${VERSION}
-🤖 Generated with GitHub Actions"
+          git merge "origin/$RELEASE_BRANCH" --no-ff -m "chore(release): merge v${VERSION} to main" \
+            -m "Automated merge of release branch for version ${VERSION}" \
+            -m "🤖 Generated with GitHub Actions"
 
           echo "Pushing to main..."
           git push origin main


### PR DESCRIPTION
## Summary

release.ymlの111行目で発生していたYAMLシンタックスエラーを修正しました。

## 問題

release.ymlがトリガーされなかった根本原因は、ワークフローファイル自体にYAMLシンタックスエラーがあったためでした：

```
Invalid workflow file: .github/workflows/release.yml#L111
You have an error in your yaml syntax on line 111
```

## 修正内容

マルチラインコミットメッセージの記述方法を修正：

**修正前（エラー）**:
```yaml
git merge "origin/$RELEASE_BRANCH" --no-ff -m "chore(release): merge v${VERSION} to main

Automated merge of release branch for version ${VERSION}
🤖 Generated with GitHub Actions"
```

**修正後**:
```yaml
git merge "origin/$RELEASE_BRANCH" --no-ff -m "chore(release): merge v${VERSION} to main" \
  -m "Automated merge of release branch for version ${VERSION}" \
  -m "🤖 Generated with GitHub Actions"
```

複数の`-m`オプションを使用することで、マルチラインコミットメッセージを正しく記述できます。

## テスト計画

1. このPRをマージ
2. release/v1.1.0ブランチを削除
3. create-release.ymlを実行
4. release.ymlが正常にトリガーされることを確認 ← これで成功するはず

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

このリリースには、エンドユーザーに見える変更はありません。

* **Chores**
  * CI/CDワークフローの内部処理を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->