### PR TITLE
fix(installer): embed Win64 cab

### DIFF
--- a/installers/windows/ollama-coordinator.wxs
+++ b/installers/windows/ollama-coordinator.wxs
@@ -15,7 +15,7 @@
       Platform="x64"
     />
 
-    <MediaTemplate />
+    <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
 
     <MajorUpgrade
       AllowDowngrades="no"


### PR DESCRIPTION
## Summary
- set <MediaTemplate EmbedCab="yes" CompressionLevel="high"> so WiX bundles cab1.cab into the MSI and install no longer fails

## Testing
- zipped artifact unaffected; Publish pipeline will rebuild MSI on next release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * Windows インストーラーのパッケージング設定を最適化しました。圧縮効率が向上し、インストーラーの処理が改善されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->