### PR TITLE
fix(agent): 設定フォームで空の数値入力を無視

### DIFF
--- a/agent/src/settings.rs
+++ b/agent/src/settings.rs
@@ -2,6 +2,7 @@ use std::{
     fs::{self, File},
     io::Write,
     path::{Path, PathBuf},
+    str::FromStr,
     sync::mpsc::{self, Sender},
     thread,
 };
@@ -13,7 +14,10 @@ use axum::{
     routing::get,
     Router,
 };
-use serde::{Deserialize, Serialize};
+use serde::{
+    de::{self, Deserializer},
+    Deserialize, Serialize,
+};
 use tokio::{net::TcpListener, runtime::Builder};
 
 use ollama_coordinator_common::error::AgentError;
@@ -47,7 +51,9 @@ struct AppState {
 #[derive(Deserialize, Debug)]
 struct SettingsFormInput {
     coordinator_url: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_opt_u16")]
     ollama_port: Option<u16>,
+    #[serde(default, deserialize_with = "deserialize_opt_u64")]
     heartbeat_interval_secs: Option<u64>,
 }
 
@@ -312,4 +318,41 @@ fn html_escape(value: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&#39;")
+}
+
+fn deserialize_opt_u16<'de, D>(deserializer: D) -> Result<Option<u16>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_optional_number(deserializer)
+}
+
+fn deserialize_opt_u64<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_optional_number(deserializer)
+}
+
+fn deserialize_optional_number<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr,
+    T::Err: std::fmt::Display,
+{
+    let raw = Option::<String>::deserialize(deserializer)?;
+    match raw {
+        Some(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                trimmed
+                    .parse::<T>()
+                    .map(Some)
+                    .map_err(|err| de::Error::custom(err.to_string()))
+            }
+        }
+        None => Ok(None),
+    }
 }


### PR DESCRIPTION
## Summary
- 設定パネルで空文字の数値フィールドを送信するとデシリアライズに失敗していた問題を修正
- 数値欄をカスタムデシリアライザで処理し、空文字は None として扱うようにしつつ通常の数値入力は従来通りパース
- コーディネーターURLのみ更新してもエラーにならず保存できることを確認

## Testing
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test
- pnpm dlx markdownlint-cli2 "**/*.md" "!node_modules" "!.git" "!.github" "!.worktrees"
- .specify/scripts/checks/check-tasks.sh (ブランチ名が SPEC-* ではなく、対象 tasks.md を特定できないためエラーで停止)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 設定入力フォームの数値フィールドの処理を改善しました。文字列から数値への変換がより堅牢になり、空の入力や不正な値が適切に処理されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->