### PR TITLE
fix(ci): update mac runners and wix asset paths

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,10 +91,10 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: windows-x86_64
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             artifact: macos-x86_64
-          - os: macos-14
+          - os: macos-latest
             target: aarch64-apple-darwin
             artifact: macos-arm64
     steps:

--- a/installers/windows/ollama-router.wxs
+++ b/installers/windows/ollama-router.wxs
@@ -39,8 +39,9 @@
   </Fragment>
 
   <Fragment>
-    <Icon Id="CoordinatorShortcutIcon" SourceFile="..\\..\\assets\\icons\\router.ico" />
-    <Icon Id="AgentShortcutIcon" SourceFile="..\\..\\assets\\icons\\node.ico" />
+    <!-- Paths are resolved relative to repository root (workflow runs from repo root) -->
+    <Icon Id="CoordinatorShortcutIcon" SourceFile="assets\\icons\\router.ico" />
+    <Icon Id="AgentShortcutIcon" SourceFile="assets\\icons\\node.ico" />
   </Fragment>
 
   <Fragment>


### PR DESCRIPTION
## Summary
- bump macOS runners to macos-15-intel and macos-latest to avoid macos-13 brownouts
- fix Windows MSI build by pointing WiX icons to repository root paths

## Testing
- not run (CI will build)