### PR TITLE
fix(installer): resolve ICE03 validation errors in WiX

### DIFF
--- a/installers/windows/ollama-router.wxs
+++ b/installers/windows/ollama-router.wxs
@@ -73,9 +73,8 @@
           Icon="CoordIcon"
           IconIndex="0"
         />
-        <RemoveFolder Id="RemoveCoordinatorProgramsFolder" Directory="ApplicationProgramsFolder" On="uninstall" />
-        <!-- Shortcut is installed under user profile; use HKCU for KeyPath to satisfy ICE38/43/57 -->
-        <RegistryValue Root="HKCU" Key="Software\\OllamaRouter" Name="CoordinatorShortcut" Type="integer" Value="1" KeyPath="yes" />
+        <RemoveFolder Id="RemoveCoordinatorProgramsFolder" Directory="ApplicationProgramsFolder" On="uninstall" KeyPath="yes" />
+        <RegistryValue Root="HKCU" Key="Software\\OllamaRouter" Name="CoordinatorShortcut" Type="integer" Value="1" />
       </Component>
 
       <Component Id="AgentStartMenuShortcut" Directory="ApplicationProgramsFolder" Guid="{B32759F0-6604-4281-8211-244CC30417B5}" Win64="yes">
@@ -88,8 +87,8 @@
           Icon="AgentIcon"
           IconIndex="0"
         />
-        <!-- Shortcut is installed under user profile; use HKCU for KeyPath to satisfy ICE38/43/57 -->
-        <RegistryValue Root="HKCU" Key="Software\\OllamaRouter" Name="AgentShortcut" Type="integer" Value="1" KeyPath="yes" />
+        <RemoveFolder Id="RemoveAgentProgramsFolder" Directory="ApplicationProgramsFolder" On="uninstall" KeyPath="yes" />
+        <RegistryValue Root="HKCU" Key="Software\\OllamaRouter" Name="AgentShortcut" Type="integer" Value="1" />
       </Component>
     </ComponentGroup>
   </Fragment>


### PR DESCRIPTION
## Summary

Windows MSIインストーラーのICE03検証エラーを解消します。

## 問題

v2.0.4のパブリッシュで以下のエラーが発生していました：

```
error LGHT0204 : ICE03: Invalid registry path
```

## 原因

- `InstallScope="perMachine"`（マシン全体インストール）
- `RegistryValue Root="HKCU"`（ユーザー固有レジストリ）

この不整合がICE03検証エラーを引き起こしていました。

## 修正内容

1. `RemoveFolder`に`KeyPath="yes"`を移動
2. `RegistryValue`から`KeyPath="yes"`を削除
3. `AgentStartMenuShortcut`にも`RemoveFolder`を追加

## 検証

- ✅ commitlint検証済み
- ✅ markdownlint検証済み

## 関連

- Fixes #19485090756 (v2.0.4 publish failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Windows インストーラの設定を調整し、ショートカットのアンインストール処理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->