### PR TITLE
fix(deps): upgrade sqlx to 0.8.6 for security

### DIFF
--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -41,7 +41,7 @@ sysinfo = "0.32"
 csv = "1.3"
 
 # 認証機能
-sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "sqlite", "migrate", "chrono", "uuid"] }
+sqlx = { version = "0.8.1", features = ["runtime-tokio-rustls", "sqlite", "migrate", "chrono", "uuid"] }
 bcrypt = "0.15"
 jsonwebtoken = "9.2"
 sha2 = "0.10"
@@ -61,7 +61,7 @@ tempfile = "3.8"
 once_cell = "1.21"
 wiremock = "0.6.5"
 criterion = { version = "0.5", features = ["async_tokio"] }
-sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "sqlite", "migrate", "chrono", "uuid"] }
+sqlx = { version = "0.8.1", features = ["runtime-tokio-rustls", "sqlite", "migrate", "chrono", "uuid"] }
 serial_test = "3.0"
 
 [[bench]]


### PR DESCRIPTION
## Summary

SQLx 0.7.xのセキュリティ脆弱性を修正するため、0.8.6にアップグレードしました。

## Vulnerability Details

**SQLx Binary Protocol Misinterpretation** (Medium Severity)
- 4GiB以上のデータをエンコードする際に長さプレフィックスがオーバーフロー
- サーバーが残りの文字列をバイナリプロトコルコマンドとして誤解釈する可能性
- DEF CON 32で報告された問題

## Changes

- `router/Cargo.toml`: sqlx バージョンを `0.7` → `0.8.1` に更新
- 実際には `0.8.6`（最新安定版）にアップグレード

## Fix Details

SQLx 0.8.1以降で以下のClippyリントが追加され、問題のあるキャストが修正されました：
- `cast_possible_truncation`
- `cast_possible_wrap`
- `cast_sign_loss`

## Test Plan

- [x] ローカル検証（cargo fmt, clippy, test）すべてパス
- [x] markdownlint検証パス
- [x] commitlint検証パス
- [ ] CI checks パス待ち

## Related Issue

Closes #3 (Dependabot Alert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)