### PR TITLE
fix(release): improve tag detection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,21 +73,28 @@ jobs:
         run: |
           # Gitタグを確認してリリース成功を判定
           git fetch --tags --force
+          git fetch origin "${GITHUB_REF#refs/heads/}:${GITHUB_REF#refs/heads/}"
 
-          # 現在のコミットに対応するタグを取得
-          CURRENT_TAG=$(git describe --exact-match HEAD 2>/dev/null || echo "")
+          # リリースブランチの最新のタグを取得（バージョン順でソート）
+          LATEST_TAG=$(git tag -l "v*" --sort=-version:refname --merged "${GITHUB_REF#refs/heads/}" | head -1)
 
-          if [ -n "$CURRENT_TAG" ] && [[ "$CURRENT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            VERSION="${CURRENT_TAG#v}"
+          if [ -n "$LATEST_TAG" ] && [[ "$LATEST_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            VERSION="${LATEST_TAG#v}"
 
-            echo "new_release_published=true" >> $GITHUB_OUTPUT
-            echo "new_release_version=$VERSION" >> $GITHUB_OUTPUT
-            echo "new_release_git_tag=$CURRENT_TAG" >> $GITHUB_OUTPUT
-            echo "✓ Release verified: $CURRENT_TAG"
+            # タグが現在のリリースブランチに含まれているか確認
+            if git merge-base --is-ancestor "$LATEST_TAG" "${GITHUB_REF#refs/heads/}"; then
+              echo "new_release_published=true" >> $GITHUB_OUTPUT
+              echo "new_release_version=$VERSION" >> $GITHUB_OUTPUT
+              echo "new_release_git_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+              echo "✓ Release verified: $LATEST_TAG"
 
-            # semantic-releaseの出力をログに記録
-            if [ "${{ steps.semantic.outputs.semantic_exit_code }}" != "0" ]; then
-              echo "⚠️ semantic-release exited with code ${{ steps.semantic.outputs.semantic_exit_code }}, but release was created successfully"
+              # semantic-releaseの出力をログに記録
+              if [ "${{ steps.semantic.outputs.semantic_exit_code }}" != "0" ]; then
+                echo "⚠️ semantic-release exited with code ${{ steps.semantic.outputs.semantic_exit_code }}, but release was created successfully"
+              fi
+            else
+              echo "new_release_published=false" >> $GITHUB_OUTPUT
+              echo "No new release published (tag not in branch)"
             fi
           else
             echo "new_release_published=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 概要

semantic-releaseが作成したタグを確実に検出するため、verifyステップのロジックを改善しました。

## 問題

前回の修正では、`git describe --exact-match HEAD` を使用していましたが、これにはタイミング問題がありました：

1. ワークフローでcheckoutした時点のHEADは、リリースコミットの**前**のコミットを指している
2. semantic-releaseがリリースコミット（`chore(release): X.Y.Z`）を作成し、タグを付与
3. verifyステップがHEADを確認するが、HEADはまだ古いコミットを指しているため、タグが見つからない

## 解決策

以下の3つの改善を実施：

### 1. リリースブランチの最新状態を明示的にfetch
```bash
git fetch origin "${GITHUB_REF#refs/heads/}:${GITHUB_REF#refs/heads/}"
```

### 2. HEADではなく、ブランチにマージされた最新タグを取得
```bash
LATEST_TAG=$(git tag -l "v*" --sort=-version:refname --merged "${GITHUB_REF#refs/heads/}" | head -1)
```

### 3. タグがブランチに含まれているかを検証
```bash
git merge-base --is-ancestor "$LATEST_TAG" "${GITHUB_REF#refs/heads/}"
```

## テスト計画

- [ ] PR #105作成後、developへマージ
- [ ] release/v2.0.5ブランチを削除して再作成
- [ ] リリースワークフローが正常に完了することを確認
- [ ] v2.0.5タグが正しく検出され、mainへのマージが実行されることを確認
- [ ] バイナリが正常に公開されることを確認

## 関連

- 前回の修正: PR #103 - `fix(release): improve release workflow robustness`
- この修正により、v2.0.5リリースを完了させる

🤖 Generated with [Claude Code](https://claude.com/claude-code)