### PR TITLE
fix(release): resolve git fetch error in verify step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,16 +73,16 @@ jobs:
         run: |
           # Gitタグを確認してリリース成功を判定
           git fetch --tags --force
-          git fetch origin "${GITHUB_REF#refs/heads/}:${GITHUB_REF#refs/heads/}"
+          git fetch origin "${GITHUB_REF#refs/heads/}"
 
           # リリースブランチの最新のタグを取得（バージョン順でソート）
-          LATEST_TAG=$(git tag -l "v*" --sort=-version:refname --merged "${GITHUB_REF#refs/heads/}" | head -1)
+          LATEST_TAG=$(git tag -l "v*" --sort=-version:refname --merged "origin/${GITHUB_REF#refs/heads/}" | head -1)
 
           if [ -n "$LATEST_TAG" ] && [[ "$LATEST_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             VERSION="${LATEST_TAG#v}"
 
             # タグが現在のリリースブランチに含まれているか確認
-            if git merge-base --is-ancestor "$LATEST_TAG" "${GITHUB_REF#refs/heads/}"; then
+            if git merge-base --is-ancestor "$LATEST_TAG" "origin/${GITHUB_REF#refs/heads/}"; then
               echo "new_release_published=true" >> $GITHUB_OUTPUT
               echo "new_release_version=$VERSION" >> $GITHUB_OUTPUT
               echo "new_release_git_tag=$LATEST_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 概要

verifyステップで発生していたgit fetchエラーを修正しました。

## 問題

前回の修正（PR #105）で、リリースブランチの最新状態を取得するために以下のコマンドを使用していましたが、チェックアウト中のブランチに対してfetchしようとしたため、Gitが拒否していました：

```bash
git fetch origin "${GITHUB_REF#refs/heads/}:${GITHUB_REF#refs/heads/}"
```

エラー:
```
fatal: refusing to fetch into branch 'refs/heads/release/v2.0.5' checked out at '/home/runner/work/ollama-router/ollama-router'
```

## 解決策

以下の3つの変更を実施：

### 1. git fetchコマンドの修正
```bash
# 修正前
git fetch origin "${GITHUB_REF#refs/heads/}:${GITHUB_REF#refs/heads/}"

# 修正後
git fetch origin "${GITHUB_REF#refs/heads/}"
```

### 2. --mergedオプションでリモートブランチを参照
```bash
# 修正前
LATEST_TAG=$(git tag -l "v*" --sort=-version:refname --merged "${GITHUB_REF#refs/heads/}" | head -1)

# 修正後
LATEST_TAG=$(git tag -l "v*" --sort=-version:refname --merged "origin/${GITHUB_REF#refs/heads/}" | head -1)
```

### 3. git merge-baseでリモートブランチを参照
```bash
# 修正前
if git merge-base --is-ancestor "$LATEST_TAG" "${GITHUB_REF#refs/heads/}"; then

# 修正後
if git merge-base --is-ancestor "$LATEST_TAG" "origin/${GITHUB_REF#refs/heads/}"; then
```

## テスト計画

- [ ] PR #106作成後、developへマージ
- [ ] release/v2.0.5ブランチを削除して再作成
- [ ] リリースワークフローが正常に完了することを確認
- [ ] v2.0.5タグが正しく検出され、mainへのマージが実行されることを確認
- [ ] バイナリが正常に公開されることを確認

## 関連

- PR #105 - tag detection改善（git fetchエラー発生）
- この修正により、v2.0.5リリースを完了させる

🤖 Generated with [Claude Code](https://claude.com/claude-code)