### PR TITLE
fix(ci): correct pwsh derive step in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,8 +59,8 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $ver = ($env:RELEASE_TAG.TrimStart('v'))
-          \"RELEASE_VERSION=$ver\" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          $ver = $env:RELEASE_TAG.TrimStart('v')
+          "RELEASE_VERSION=$ver" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Windows ジョブのバージョン抽出が bash 記法のまま実行されて失敗していたため、publish.yml の Windows 用ステップを正しい PowerShell 記法に修正しました。

-  を  形式に修正
- 追加のエスケープを除去し、 への書き込みを poweshell で実行

再度 publish を試す前にこの修正を main に取り込む必要があります。

テスト: なし（wf 定義のみ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ビルドワークフローの内部構文を改善しました。ユーザーに対する機能的な影響はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->