### PR TITLE
ci(workflow): release-please PRでprepare-releaseが実行されないよう修正

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,16 +18,9 @@ jobs:
   validate-and-merge:
     name: Validate and merge to main
     runs-on: ubuntu-latest
-    # PRイベントの場合のみ実行
-    if: github.event_name == 'pull_request'
+    # developブランチからのPRのみ実行（release-pleaseのPRは除外）
+    if: github.event_name == 'pull_request' && github.head_ref == 'develop'
     steps:
-      - name: Check source branch
-        if: github.head_ref != 'develop'
-        run: |
-          echo "::error::Only PRs from 'develop' branch are allowed to main"
-          echo "Source branch: ${{ github.head_ref }}"
-          exit 1
-
       - name: Auto-merge PR from develop
         env:
           GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `prepare-release.yml`のvalidate-and-mergeジョブがrelease-pleaseのPRでもトリガーされてエラーになっていた問題を修正
- if条件で`github.head_ref == 'develop'`を追加し、developブランチからのPRのみで実行されるよう変更

## Problem

release-pleaseが作成するPR（`release-please--branches--main--components--ollama-router-release`ブランチ）がmainへマージされる際に、`prepare-release.yml`がトリガーされ、「Only PRs from 'develop' branch are allowed to main」というエラーが発生していた。

## Solution

ジョブレベルのif条件を変更:
```yaml
# Before
if: github.event_name == 'pull_request'

# After  
if: github.event_name == 'pull_request' && github.head_ref == 'develop'
```

## Test plan

- [ ] release-pleaseのPRがマージされた際にprepare-release.ymlがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)