### PR TITLE
fix(docs): releaseコマンドの使い方を正しいコマンドに修正

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -23,8 +23,10 @@ tags: [project]
 
 ## 使い方
 
+GitHub CLIで直接ワークフローを実行します：
+
 ```bash
-scripts/prepare-release.sh
+gh workflow run prepare-release.yml
 ```
 
 ## 注意


### PR DESCRIPTION
## Summary

- `.claude/commands/release.md`の使い方セクションを修正
- 存在しない`scripts/prepare-release.sh`への参照を`gh workflow run prepare-release.yml`に変更

## Test plan

- [ ] ドキュメントの内容が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)