### PR TITLE
refactor!: rename environment variables and fix CI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,8 +33,8 @@ Router (OpenAI-compatible)
 
 ## Configuration Surface
 - Router environment: `ROUTER_PORT`, `DATABASE_URL`, cloud keys and base URLs.
-- Node environment: `OLLAMA_ROUTER_URL`, `OLLAMA_NODE_PORT`,
-  `OLLAMA_ALLOW_NO_GPU` (opt-out of GPU requirement).
+- Node environment: `LLM_ROUTER_URL`, `LLM_NODE_PORT`,
+  `LLM_ALLOW_NO_GPU` (opt-out of GPU requirement).
 
 ## Deployment Options
 - Bare metal: build router with `cargo build -p llm-router --release`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,7 +32,7 @@ pnpm install --frozen-lockfile   # for lint tooling; node_modules already vendor
 ## Environment Variables
 - Router: `ROUTER_PORT`, `DATABASE_URL`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`,
   `ANTHROPIC_API_KEY`.
-- Node: `OLLAMA_ROUTER_URL`, `OLLAMA_NODE_PORT`, `OLLAMA_ALLOW_NO_GPU=false`
+- Node: `LLM_ROUTER_URL`, `LLM_NODE_PORT`, `LLM_ALLOW_NO_GPU=false`
   by default.
 
 ## Debugging Tips

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,10 +44,10 @@ cmake --build build --config Release
   - `DATABASE_URL` (default `sqlite:$HOME/.or/router.db`)
   - クラウドキー: `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY`
 - ノード（C++）
-  - `OLLAMA_ROUTER_URL` (例: `http://localhost:8080`)
-  - `OLLAMA_NODE_PORT` (default `11434`)
-  - `OLLAMA_BIND_ADDRESS` (default `0.0.0.0`)
-  - `OLLAMA_ALLOW_NO_GPU` を `true` にするとGPU必須を無効化（デフォルトは禁止）
+  - `LLM_ROUTER_URL` (例: `http://localhost:8080`)
+  - `LLM_NODE_PORT` (default `11434`)
+  - `LLM_BIND_ADDRESS` (default `0.0.0.0`)
+  - `LLM_ALLOW_NO_GPU` を `true` にするとGPU必須を無効化（デフォルトは禁止）
 
 ## 5) 起動例
 ```bash

--- a/README.ja.md
+++ b/README.ja.md
@@ -79,18 +79,18 @@ npm run start:node
 
 # 手動でビルドする場合:
 # cd node && cmake -B build -S . && cmake --build build --config Release
-# OLLAMA_ROUTER_URL=http://localhost:8080 ./node/build/llm-node
+# LLM_ROUTER_URL=http://localhost:8080 ./node/build/llm-node
 ```
 
 **環境変数:**
 
 | 変数 | デフォルト | 説明 |
 |-----|-----------|------|
-| `OLLAMA_ROUTER_URL` | `http://127.0.0.1:11434` | 登録先ルーターのURL |
-| `OLLAMA_NODE_PORT` | `11435` | ノードのリッスンポート |
-| `OLLAMA_MODELS_DIR` | `~/.ollama/models` | モデル保存ディレクトリ |
-| `OLLAMA_ALLOW_NO_GPU` | `false` | GPU無しでの起動を許可 |
-| `OLLAMA_HEARTBEAT_SECS` | `10` | ハートビート間隔（秒） |
+| `LLM_ROUTER_URL` | `http://127.0.0.1:11434` | 登録先ルーターのURL |
+| `LLM_NODE_PORT` | `11435` | ノードのリッスンポート |
+| `LLM_MODELS_DIR` | `~/.ollama/models` | モデル保存ディレクトリ |
+| `LLM_ALLOW_NO_GPU` | `false` | GPU無しでの起動を許可 |
+| `LLM_HEARTBEAT_SECS` | `10` | ハートビート間隔（秒） |
 
 **Docker:**
 
@@ -100,7 +100,7 @@ docker build --build-arg CUDA=cpu -t llm-node-cpp:latest node/
 
 # 起動
 docker run --rm -p 11435:11435 \
-  -e OLLAMA_ROUTER_URL=http://host.docker.internal:8080 \
+  -e LLM_ROUTER_URL=http://host.docker.internal:8080 \
   llm-node-cpp:latest
 ```
 
@@ -411,9 +411,9 @@ GitHubリリースには各プラットフォーム向けのバイナリを同�
 
 #### Agent
 - `ROUTER_URL`: CoordinatorのURL（デフォルト: `http://localhost:8080`）
-- `OLLAMA_PORT`: Ollamaポート番号（デフォルト: `11434`）
-- `OLLAMA_AGENT_MACHINE_NAME`: Coordinator登録時に使用するマシン名。未設定時は `OLLAMA_MACHINE_NAME` → `HOSTNAME` → `whoami::hostname()` の順で自動判定されます。
-- `OLLAMA_PULL_TIMEOUT_SECS`: モデル自動ダウンロード時のHTTPタイムアウト秒数。未設定または `0` の場合はタイムアウトなしで待機します。
+- `LLM_PORT`: Ollamaポート番号（デフォルト: `11434`）
+- `LLM_AGENT_MACHINE_NAME`: Coordinator登録時に使用するマシン名。未設定時は `LLM_MACHINE_NAME` → `HOSTNAME` → `whoami::hostname()` の順で自動判定されます。
+- `LLM_PULL_TIMEOUT_SECS`: モデル自動ダウンロード時のHTTPタイムアウト秒数。未設定または `0` の場合はタイムアウトなしで待機します。
 - `ROUTER_REGISTER_RETRY_SECS`: 登録リトライ間隔（秒）。未設定時は `5` 秒、`0` を指定すると即座に再試行します。
 - `ROUTER_REGISTER_MAX_RETRIES`: 登録リトライ上限回数。未設定または `0` の場合は成功するまで無制限に再試行します。
 

--- a/README.md
+++ b/README.md
@@ -84,18 +84,18 @@ npm run start:node
 
 # Or manually:
 # cd node && cmake -B build -S . && cmake --build build --config Release
-# OLLAMA_ROUTER_URL=http://localhost:8080 ./node/build/llm-node
+# LLM_ROUTER_URL=http://localhost:8080 ./node/build/llm-node
 ```
 
 **Environment Variables:**
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OLLAMA_ROUTER_URL` | `http://127.0.0.1:11434` | Router URL to register with |
-| `OLLAMA_NODE_PORT` | `11435` | Node listen port |
-| `OLLAMA_MODELS_DIR` | `~/.ollama/models` | Model storage directory |
-| `OLLAMA_ALLOW_NO_GPU` | `false` | Allow running without GPU |
-| `OLLAMA_HEARTBEAT_SECS` | `10` | Heartbeat interval (seconds) |
+| `LLM_ROUTER_URL` | `http://127.0.0.1:11434` | Router URL to register with |
+| `LLM_NODE_PORT` | `11435` | Node listen port |
+| `LLM_MODELS_DIR` | `~/.ollama/models` | Model storage directory |
+| `LLM_ALLOW_NO_GPU` | `false` | Allow running without GPU |
+| `LLM_HEARTBEAT_SECS` | `10` | Heartbeat interval (seconds) |
 
 **Docker:**
 
@@ -105,7 +105,7 @@ docker build --build-arg CUDA=cpu -t llm-node:latest node/
 
 # Run
 docker run --rm -p 11435:11435 \
-  -e OLLAMA_ROUTER_URL=http://host.docker.internal:8080 \
+  -e LLM_ROUTER_URL=http://host.docker.internal:8080 \
   llm-node:latest
 ```
 
@@ -446,9 +446,9 @@ Agents automatically detect GPU on startup. **GPU is required** for agent regist
 If automatic detection fails, set environment variables:
 
 ```bash
-OLLAMA_GPU_AVAILABLE=true \
-OLLAMA_GPU_MODEL="Your GPU Model" \
-OLLAMA_GPU_COUNT=1 \
+LLM_GPU_AVAILABLE=true \
+LLM_GPU_MODEL="Your GPU Model" \
+LLM_GPU_COUNT=1 \
 ./target/release/ollama-router-agent
 ```
 
@@ -512,13 +512,13 @@ OLLAMA_GPU_COUNT=1 \
 
 #### Agent
 - `ROUTER_URL`: Coordinator URL (default: `http://localhost:8080`)
-- `OLLAMA_PORT`: Ollama port number (default: `11434`)
-- `OLLAMA_GPU_AVAILABLE`: Manual GPU availability flag (optional, auto-detected)
-- `OLLAMA_GPU_MODEL`: Manual GPU model name (optional, auto-detected)
-- `OLLAMA_GPU_COUNT`: Manual GPU count (optional, auto-detected)
-- `OLLAMA_DEFAULT_MODEL`: Default LLM model to download (optional, auto-selected based on memory)
-- `OLLAMA_PULL_TIMEOUT_SECS`: Timeout for model download in seconds (optional)
-- `OLLAMA_API_BASE`: Custom Ollama API base URL (optional, default: `http://127.0.0.1:11434`)
+- `LLM_PORT`: Ollama port number (default: `11434`)
+- `LLM_GPU_AVAILABLE`: Manual GPU availability flag (optional, auto-detected)
+- `LLM_GPU_MODEL`: Manual GPU model name (optional, auto-detected)
+- `LLM_GPU_COUNT`: Manual GPU count (optional, auto-detected)
+- `LLM_DEFAULT_MODEL`: Default LLM model to download (optional, auto-selected based on memory)
+- `LLM_PULL_TIMEOUT_SECS`: Timeout for model download in seconds (optional)
+- `LLM_API_BASE`: Custom Ollama API base URL (optional, default: `http://127.0.0.1:11434`)
 
 ## Development
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 ## 起動時に GPU が見つからない
 - 確認: `nvidia-smi` または `CUDA_VISIBLE_DEVICES`
-- 環境変数で無効化: ノード側 `OLLAMA_ALLOW_NO_GPU=true`（デフォルトは禁止）
+- 環境変数で無効化: ノード側 `LLM_ALLOW_NO_GPU=true`（デフォルトは禁止）
 - それでも失敗する場合は NVML ライブラリの有無を確認
 
 ## クラウドモデルが 401/400 を返す
@@ -12,7 +12,7 @@
 
 ## ポート競合で起動しない
 - ルーター: `ROUTER_PORT` を変更（例: `ROUTER_PORT=18080`）
-- ノード: `OLLAMA_NODE_PORT` または `--port` で変更
+- ノード: `LLM_NODE_PORT` または `--port` で変更
 
 ## SQLite ファイル作成に失敗
 - `DATABASE_URL` のパス先ディレクトリの書き込み権限を確認

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,15 +46,15 @@ services:
       context: ./node
       dockerfile: Dockerfile
       args:
-        CUDA: ${OLLAMA_CPP_CUDA:-cpu} # cpu | cuda
+        CUDA: ${LLM_CPP_CUDA:-cpu} # cpu | cuda
     container_name: llm-node
     depends_on:
       - llm-router
     environment:
-      - OLLAMA_ROUTER_URL=http://llm-router:8080
-      - OLLAMA_MODELS_DIR=/models
-      - OLLAMA_NODE_PORT=11435
-      - OLLAMA_ALLOW_NO_GPU=1
+      - LLM_ROUTER_URL=http://llm-router:8080
+      - LLM_MODELS_DIR=/models
+      - LLM_NODE_PORT=11435
+      - LLM_ALLOW_NO_GPU=1
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-}
     runtime: ${DOCKER_RUNTIME:-runc} # set to nvidia when using GPU
     volumes:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -62,10 +62,10 @@ Expose the port as configured (`-p 8080:8080`) and open the dashboard from the h
 | Export list            | Use “JSONエクスポート” or “CSVエクスポート” buttons to download the filtered list.                        |
 | View CPU/memory/GPU trend | Open “詳細” and scroll to the “メトリクス” section for CPU/メモリ/GPUの折れ線グラフ (latest 120 samples). |
 | Monitor GPU utilisation | The stats card “平均GPU使用率” displays the current average GPU utilisation and memory usage across all fresh agents. |
-| Override Ollama download | Set `OLLAMA_DOWNLOAD_URL` (and optionally `OLLAMA_PLATFORM` such as `linux-arm64`) when running the agent to force a specific binary. |
-| Auto model preload   | Agents now pull `gpt-oss:20b` automatically once Ollama is up. Override with `OLLAMA_DEFAULT_MODEL`; adjust the pull timeout with `OLLAMA_PULL_TIMEOUT_SECS`. |
+| Override Ollama download | Set `LLM_DOWNLOAD_URL` (and optionally `LLM_PLATFORM` such as `linux-arm64`) when running the agent to force a specific binary. |
+| Auto model preload   | Agents now pull `gpt-oss:20b` automatically once Ollama is up. Override with `LLM_DEFAULT_MODEL`; adjust the pull timeout with `LLM_PULL_TIMEOUT_SECS`. |
 | View loaded models    | The “モデル” column shows each agent’s reported models (top entry + preview). Open “詳細” to see the full, deduplicated list. |
-| Run multiple agents on one host | Launch each agent with a unique `OLLAMA_PORT` (e.g. 11434, 12434…). The coordinator now treats ports on the same machine as distinct agents. |
+| Run multiple agents on one host | Launch each agent with a unique `LLM_PORT` (e.g. 11434, 12434…). The coordinator now treats ports on the same machine as distinct agents. |
 
 Pagination is shown once the list exceeds 50 entries; use the arrows below the table to move between pages.
 

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -37,9 +37,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 FROM runtime-${CUDA} AS runtime
 
-ENV OLLAMA_MODELS_DIR=/var/lib/ollama/models
-ENV OLLAMA_ROUTER_URL=http://router:8080
-ENV OLLAMA_NODE_PORT=11435
+ENV LLM_MODELS_DIR=/var/lib/ollama/models
+ENV LLM_ROUTER_URL=http://router:8080
+ENV LLM_NODE_PORT=11435
 
 WORKDIR /app
 COPY --from=build /usr/local /usr/local

--- a/node/include/models/model_sync.h
+++ b/node/include/models/model_sync.h
@@ -78,7 +78,7 @@ public:
 
     void setModelOverrides(std::unordered_map<std::string, ModelOverrides> overrides);
 
-    // 並列ダウンロードの同時実行数（デフォルト4）。環境変数 OLLAMA_DL_CONCURRENCY で上書き。
+    // 並列ダウンロードの同時実行数（デフォルト4）。環境変数 LLM_DL_CONCURRENCY で上書き。
     static size_t defaultConcurrency();
 
     // 直近の同期ステータスを取得

--- a/node/include/system/gpu_detector.h
+++ b/node/include/system/gpu_detector.h
@@ -46,7 +46,7 @@ private:
     std::vector<GpuDevice> detectMetal();
     std::vector<GpuDevice> detectRocm();
 
-#ifdef OLLAMA_NODE_TESTING
+#ifdef LLM_NODE_TESTING
 public:
     // テスト専用: 検出結果を直接セットして計算ロジックを検証する
     void setDetectedDevicesForTest(std::vector<GpuDevice> devices);

--- a/node/src/main.cpp
+++ b/node/src/main.cpp
@@ -230,7 +230,7 @@ void signalHandler(int signal) {
     ollama_node::request_shutdown();
 }
 
-#ifndef OLLAMA_NODE_TESTING
+#ifndef LLM_NODE_TESTING
 int main(int argc, char* argv[]) {
     // Set up signal handlers
     signal(SIGINT, signalHandler);
@@ -243,7 +243,7 @@ int main(int argc, char* argv[]) {
 }
 #endif
 
-#ifdef OLLAMA_NODE_TESTING
+#ifdef LLM_NODE_TESTING
 extern "C" int ollama_node_run_for_test() {
     auto cfg = ollama_node::loadNodeConfig();
     // short intervals for tests

--- a/node/src/models/model_downloader.cpp
+++ b/node/src/models/model_downloader.cpp
@@ -294,7 +294,7 @@ std::string ModelDownloader::fetchManifest(const std::string& model_id) {
     std::ofstream ofs(out_path, std::ios::binary | std::ios::trunc);
     ofs << res->body;
     // log applied config for diagnostics (opt-in)
-    if (const char* logenv = std::getenv("OLLAMA_DL_LOG_CONFIG")) {
+    if (const char* logenv = std::getenv("LLM_DL_LOG_CONFIG")) {
         if (std::string(logenv) == "1" || std::string(logenv) == "true") {
             auto cfg_pair = loadDownloadConfigWithLog();
             auto cfg = cfg_pair.first;

--- a/node/src/models/model_sync.cpp
+++ b/node/src/models/model_sync.cpp
@@ -343,7 +343,7 @@ bool ModelSync::downloadModel(ModelDownloader& downloader,
                 downloader.setChunkSize(applied_chunk);
                 downloader.setMaxBytesPerSec(applied_bps);
 
-                if (const char* logenv = std::getenv("OLLAMA_DL_LOG_CONFIG")) {
+                if (const char* logenv = std::getenv("LLM_DL_LOG_CONFIG")) {
                     if (std::string(logenv) == "1" || std::string(logenv) == "true") {
                         const char* source = "default";
                         if (file_chunk > 0 || file_bps > 0) source = "manifest";

--- a/node/src/system/gpu_detector.cpp
+++ b/node/src/system/gpu_detector.cpp
@@ -234,7 +234,7 @@ std::vector<GpuDevice> GpuDetector::detectRocm() {
     return devices;
 }
 
-#ifdef OLLAMA_NODE_TESTING
+#ifdef LLM_NODE_TESTING
 void GpuDetector::setDetectedDevicesForTest(std::vector<GpuDevice> devices) {
     detected_devices_ = std::move(devices);
 }

--- a/node/src/utils/config.cpp
+++ b/node/src/utils/config.cpp
@@ -24,7 +24,7 @@ std::pair<DownloadConfig, std::string> loadDownloadConfigWithLog() {
     bool used_file = false;
     bool used_env = false;
 
-    // Optional JSON config file: path from OLLAMA_DL_CONFIG or ~/.ollama/config.json
+    // Optional JSON config file: path from LLM_DL_CONFIG or ~/.ollama/config.json
     auto load_from_file = [&](const std::filesystem::path& path) {
         if (!std::filesystem::exists(path)) return false;
         try {
@@ -46,7 +46,7 @@ std::pair<DownloadConfig, std::string> loadDownloadConfigWithLog() {
         }
     };
 
-    if (const char* env = std::getenv("OLLAMA_DL_CONFIG")) {
+    if (const char* env = std::getenv("LLM_DL_CONFIG")) {
         if (load_from_file(env)) {
             used_file = true;
         }
@@ -60,7 +60,7 @@ std::pair<DownloadConfig, std::string> loadDownloadConfigWithLog() {
         } catch (...) {}
     }
 
-    if (const char* env = std::getenv("OLLAMA_DL_MAX_RETRIES")) {
+    if (const char* env = std::getenv("LLM_DL_MAX_RETRIES")) {
         try {
             int v = std::stoi(env);
             if (v >= 0) cfg.max_retries = v;
@@ -69,7 +69,7 @@ std::pair<DownloadConfig, std::string> loadDownloadConfigWithLog() {
         } catch (...) {}
     }
 
-    if (const char* env = std::getenv("OLLAMA_DL_BACKOFF_MS")) {
+    if (const char* env = std::getenv("LLM_DL_BACKOFF_MS")) {
         try {
             long long ms = std::stoll(env);
             if (ms >= 0) cfg.backoff = std::chrono::milliseconds(ms);
@@ -78,7 +78,7 @@ std::pair<DownloadConfig, std::string> loadDownloadConfigWithLog() {
         } catch (...) {}
     }
 
-    if (const char* env = std::getenv("OLLAMA_DL_CONCURRENCY")) {
+    if (const char* env = std::getenv("LLM_DL_CONCURRENCY")) {
         try {
             long long v = std::stoll(env);
             if (v > 0 && v < 64) cfg.max_concurrency = static_cast<size_t>(v);
@@ -87,7 +87,7 @@ std::pair<DownloadConfig, std::string> loadDownloadConfigWithLog() {
         } catch (...) {}
     }
 
-    if (const char* env = std::getenv("OLLAMA_DL_MAX_BPS")) {
+    if (const char* env = std::getenv("LLM_DL_MAX_BPS")) {
         try {
             long long v = std::stoll(env);
             if (v > 0) cfg.max_bytes_per_sec = static_cast<size_t>(v);
@@ -96,7 +96,7 @@ std::pair<DownloadConfig, std::string> loadDownloadConfigWithLog() {
         } catch (...) {}
     }
 
-    if (const char* env = std::getenv("OLLAMA_DL_CHUNK")) {
+    if (const char* env = std::getenv("LLM_DL_CHUNK")) {
         try {
             long long v = std::stoll(env);
             if (v > 0 && v <= 1 << 20) cfg.chunk_size = static_cast<size_t>(v);
@@ -167,7 +167,7 @@ std::pair<NodeConfig, std::string> loadNodeConfigWithLog() {
 
     // file
     std::filesystem::path cfg_path;
-    if (const char* env = std::getenv("OLLAMA_NODE_CONFIG")) {
+    if (const char* env = std::getenv("LLM_NODE_CONFIG")) {
         cfg_path = env;
     } else {
         cfg_path = defaultConfigPath();
@@ -188,31 +188,31 @@ std::pair<NodeConfig, std::string> loadNodeConfigWithLog() {
         return std::nullopt;
     };
 
-    if (auto v = getenv_str("OLLAMA_ROUTER_URL")) {
+    if (auto v = getenv_str("LLM_ROUTER_URL")) {
         cfg.router_url = *v;
         log << "env:ROUTER_URL=" << *v << " ";
         used_env = true;
     }
-    if (auto v = getenv_str("OLLAMA_MODELS_DIR")) {
+    if (auto v = getenv_str("LLM_MODELS_DIR")) {
         cfg.models_dir = *v;
         log << "env:MODELS_DIR=" << *v << " ";
         used_env = true;
     }
-    if (auto v = getenv_str("OLLAMA_NODE_PORT")) {
+    if (auto v = getenv_str("LLM_NODE_PORT")) {
         try {
             cfg.node_port = std::stoi(*v);
             log << "env:NODE_PORT=" << cfg.node_port << " ";
             used_env = true;
         } catch (...) {}
     }
-    if (auto v = getenv_str("OLLAMA_HEARTBEAT_SECS")) {
+    if (auto v = getenv_str("LLM_HEARTBEAT_SECS")) {
         try {
             cfg.heartbeat_interval_sec = std::stoi(*v);
             log << "env:HEARTBEAT_SECS=" << cfg.heartbeat_interval_sec << " ";
             used_env = true;
         } catch (...) {}
     }
-    if (auto v = getenv_str("OLLAMA_ALLOW_NO_GPU")) {
+    if (auto v = getenv_str("LLM_ALLOW_NO_GPU")) {
         std::string s = *v;
         std::transform(s.begin(), s.end(), s.begin(), ::tolower);
         if (s == "1" || s == "true" || s == "yes") {
@@ -222,13 +222,13 @@ std::pair<NodeConfig, std::string> loadNodeConfigWithLog() {
         }
     }
 
-    if (auto v = getenv_str("OLLAMA_BIND_ADDRESS")) {
+    if (auto v = getenv_str("LLM_BIND_ADDRESS")) {
         cfg.bind_address = *v;
         log << "env:BIND_ADDRESS=" << *v << " ";
         used_env = true;
     }
 
-    if (auto v = getenv_str("OLLAMA_NODE_IP")) {
+    if (auto v = getenv_str("LLM_NODE_IP")) {
         cfg.ip_address = *v;
         log << "env:NODE_IP=" << *v << " ";
         used_env = true;

--- a/node/tests/unit/utils_config_test.cpp
+++ b/node/tests/unit/utils_config_test.cpp
@@ -32,8 +32,8 @@ private:
 };
 
 TEST(UtilsConfigTest, LoadsNodeConfigFromFileWithLock) {
-    EnvGuard guard({"OLLAMA_NODE_CONFIG", "OLLAMA_ROUTER_URL", "OLLAMA_MODELS_DIR",
-                    "OLLAMA_NODE_PORT", "OLLAMA_HEARTBEAT_SECS", "OLLAMA_ALLOW_NO_GPU"});
+    EnvGuard guard({"LLM_NODE_CONFIG", "LLM_ROUTER_URL", "LLM_MODELS_DIR",
+                    "LLM_NODE_PORT", "LLM_HEARTBEAT_SECS", "LLM_ALLOW_NO_GPU"});
 
     fs::path tmp = fs::temp_directory_path() / "nodecfg.json";
     std::ofstream(tmp) << R"({
@@ -43,7 +43,7 @@ TEST(UtilsConfigTest, LoadsNodeConfigFromFileWithLock) {
         "heartbeat_interval_sec": 3,
         "require_gpu": false
     })";
-    setenv("OLLAMA_NODE_CONFIG", tmp.string().c_str(), 1);
+    setenv("LLM_NODE_CONFIG", tmp.string().c_str(), 1);
 
     auto info = loadNodeConfigWithLog();
     auto cfg = info.first;
@@ -59,15 +59,15 @@ TEST(UtilsConfigTest, LoadsNodeConfigFromFileWithLock) {
 }
 
 TEST(UtilsConfigTest, EnvOverridesNodeConfig) {
-    EnvGuard guard({"OLLAMA_ROUTER_URL", "OLLAMA_MODELS_DIR", "OLLAMA_NODE_PORT",
-                    "OLLAMA_HEARTBEAT_SECS", "OLLAMA_ALLOW_NO_GPU", "OLLAMA_NODE_CONFIG"});
+    EnvGuard guard({"LLM_ROUTER_URL", "LLM_MODELS_DIR", "LLM_NODE_PORT",
+                    "LLM_HEARTBEAT_SECS", "LLM_ALLOW_NO_GPU", "LLM_NODE_CONFIG"});
 
-    unsetenv("OLLAMA_NODE_CONFIG");
-    setenv("OLLAMA_ROUTER_URL", "http://env:1234", 1);
-    setenv("OLLAMA_MODELS_DIR", "/env/models", 1);
-    setenv("OLLAMA_NODE_PORT", "19000", 1);
-    setenv("OLLAMA_HEARTBEAT_SECS", "7", 1);
-    setenv("OLLAMA_ALLOW_NO_GPU", "true", 1);
+    unsetenv("LLM_NODE_CONFIG");
+    setenv("LLM_ROUTER_URL", "http://env:1234", 1);
+    setenv("LLM_MODELS_DIR", "/env/models", 1);
+    setenv("LLM_NODE_PORT", "19000", 1);
+    setenv("LLM_HEARTBEAT_SECS", "7", 1);
+    setenv("LLM_ALLOW_NO_GPU", "true", 1);
 
     auto cfg = loadNodeConfig();
     EXPECT_EQ(cfg.router_url, "http://env:1234");

--- a/router/src/api/logs.rs
+++ b/router/src/api/logs.rs
@@ -191,7 +191,7 @@ mod tests {
     async fn coordinator_logs_endpoint_returns_entries() {
         let _guard = TEST_LOCK.lock().await;
         let temp = tempdir().unwrap();
-        std::env::set_var("OLLAMA_ROUTER_DATA_DIR", temp.path());
+        std::env::set_var("LLM_ROUTER_DATA_DIR", temp.path());
         let log_path = logging::log_file_path().unwrap();
         if let Some(parent) = log_path.parent() {
             std::fs::create_dir_all(parent).unwrap();
@@ -211,7 +211,7 @@ mod tests {
         assert_eq!(response.entries.len(), 2);
         assert_eq!(response.entries[1].message.as_deref(), Some("world"));
 
-        std::env::remove_var("OLLAMA_ROUTER_DATA_DIR");
+        std::env::remove_var("LLM_ROUTER_DATA_DIR");
     }
 
     #[tokio::test]

--- a/router/src/api/nodes.rs
+++ b/router/src/api/nodes.rs
@@ -102,7 +102,7 @@ pub async fn register_node(
     let node_api_base = format!("http://{}:{}", req.ip_address, node_api_port);
     let health_url = format!("{}/v1/models", node_api_base);
 
-    let skip_health_check = cfg!(test) || std::env::var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK").is_ok();
+    let skip_health_check = cfg!(test) || std::env::var("LLM_ROUTER_SKIP_HEALTH_CHECK").is_ok();
     let (loaded_models, initializing, ready_models) = if skip_health_check {
         (vec!["gpt-oss:20b".to_string()], false, Some((1, 1)))
     } else {

--- a/router/src/db/mod.rs
+++ b/router/src/db/mod.rs
@@ -39,7 +39,7 @@ use uuid::Uuid;
 /// データファイルのパスを取得
 fn get_data_file_path() -> RouterResult<PathBuf> {
     // テスト用に環境変数でデータディレクトリを指定可能にする
-    let data_dir = if let Ok(test_dir) = std::env::var("OLLAMA_ROUTER_DATA_DIR") {
+    let data_dir = if let Ok(test_dir) = std::env::var("LLM_ROUTER_DATA_DIR") {
         PathBuf::from(test_dir)
     } else {
         let home = std::env::var("HOME")
@@ -214,7 +214,7 @@ mod tests {
 
         // 一時ディレクトリを使用（_guardでスコープ内保持）
         let _guard = tempdir().unwrap();
-        std::env::set_var("OLLAMA_ROUTER_DATA_DIR", _guard.path());
+        std::env::set_var("LLM_ROUTER_DATA_DIR", _guard.path());
 
         let result = init_storage().await;
         assert!(result.is_ok());
@@ -223,7 +223,7 @@ mod tests {
         let data_file = get_data_file_path().unwrap();
         assert!(data_file.exists());
 
-        std::env::remove_var("OLLAMA_ROUTER_DATA_DIR");
+        std::env::remove_var("LLM_ROUTER_DATA_DIR");
     }
 
     #[tokio::test]
@@ -232,7 +232,7 @@ mod tests {
 
         // 一時ディレクトリを使用（_guardでスコープ内保持）
         let _guard = tempdir().unwrap();
-        std::env::set_var("OLLAMA_ROUTER_DATA_DIR", _guard.path());
+        std::env::set_var("LLM_ROUTER_DATA_DIR", _guard.path());
 
         init_storage().await.unwrap();
 
@@ -276,7 +276,7 @@ mod tests {
         assert_eq!(loaded_nodes[0].id, node.id);
         assert_eq!(loaded_nodes[0].machine_name, node.machine_name);
 
-        std::env::remove_var("OLLAMA_ROUTER_DATA_DIR");
+        std::env::remove_var("LLM_ROUTER_DATA_DIR");
     }
 
     #[tokio::test]
@@ -285,7 +285,7 @@ mod tests {
 
         // 一時ディレクトリを使用（_guardでスコープ内保持）
         let _guard = tempdir().unwrap();
-        std::env::set_var("OLLAMA_ROUTER_DATA_DIR", _guard.path());
+        std::env::set_var("LLM_ROUTER_DATA_DIR", _guard.path());
 
         init_storage().await.unwrap();
 
@@ -326,7 +326,7 @@ mod tests {
         let loaded_nodes = load_nodes().await.unwrap();
         assert_eq!(loaded_nodes.len(), 0);
 
-        std::env::remove_var("OLLAMA_ROUTER_DATA_DIR");
+        std::env::remove_var("LLM_ROUTER_DATA_DIR");
     }
 
     #[tokio::test]
@@ -335,7 +335,7 @@ mod tests {
 
         // 一時ディレクトリを使用（_guardでスコープ内保持）
         let _guard = tempdir().unwrap();
-        std::env::set_var("OLLAMA_ROUTER_DATA_DIR", _guard.path());
+        std::env::set_var("LLM_ROUTER_DATA_DIR", _guard.path());
 
         init_storage().await.unwrap();
 
@@ -413,7 +413,7 @@ mod tests {
         assert_eq!(loaded_nodes[0].machine_name, "test-machine-2");
         assert_eq!(loaded_nodes[0].ollama_port, 11435);
 
-        std::env::remove_var("OLLAMA_ROUTER_DATA_DIR");
+        std::env::remove_var("LLM_ROUTER_DATA_DIR");
     }
 
     #[tokio::test]
@@ -421,7 +421,7 @@ mod tests {
         let _lock = test_utils::TEST_LOCK.lock().await;
 
         let _guard = tempdir().unwrap();
-        std::env::set_var("OLLAMA_ROUTER_DATA_DIR", _guard.path());
+        std::env::set_var("LLM_ROUTER_DATA_DIR", _guard.path());
 
         init_storage().await.unwrap();
 
@@ -445,6 +445,6 @@ mod tests {
             entries
         );
 
-        std::env::remove_var("OLLAMA_ROUTER_DATA_DIR");
+        std::env::remove_var("LLM_ROUTER_DATA_DIR");
     }
 }

--- a/router/src/db/request_history.rs
+++ b/router/src/db/request_history.rs
@@ -224,7 +224,7 @@ pub struct FilteredRecords {
 
 /// 履歴ファイルのパスを取得
 fn get_history_file_path() -> RouterResult<PathBuf> {
-    let data_dir = if let Ok(test_dir) = std::env::var("OLLAMA_ROUTER_DATA_DIR") {
+    let data_dir = if let Ok(test_dir) = std::env::var("LLM_ROUTER_DATA_DIR") {
         PathBuf::from(test_dir)
     } else {
         let home = std::env::var("HOME")
@@ -290,7 +290,7 @@ mod tests {
         let _lock = TEST_LOCK.lock().await;
 
         let temp_dir = tempdir().unwrap();
-        std::env::set_var("OLLAMA_ROUTER_DATA_DIR", temp_dir.path());
+        std::env::set_var("LLM_ROUTER_DATA_DIR", temp_dir.path());
 
         let storage = RequestHistoryStorage::new().unwrap();
         let record = create_test_record(Utc::now());
@@ -301,7 +301,7 @@ mod tests {
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].id, record.id);
 
-        std::env::remove_var("OLLAMA_ROUTER_DATA_DIR");
+        std::env::remove_var("LLM_ROUTER_DATA_DIR");
     }
 
     #[tokio::test]
@@ -309,7 +309,7 @@ mod tests {
         let _lock = TEST_LOCK.lock().await;
 
         let temp_dir = tempdir().unwrap();
-        std::env::set_var("OLLAMA_ROUTER_DATA_DIR", temp_dir.path());
+        std::env::set_var("LLM_ROUTER_DATA_DIR", temp_dir.path());
 
         let storage = RequestHistoryStorage::new().unwrap();
 
@@ -330,7 +330,7 @@ mod tests {
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].id, new_record.id);
 
-        std::env::remove_var("OLLAMA_ROUTER_DATA_DIR");
+        std::env::remove_var("LLM_ROUTER_DATA_DIR");
     }
 
     #[tokio::test]
@@ -338,7 +338,7 @@ mod tests {
         let _lock = TEST_LOCK.lock().await;
 
         let temp_dir = tempdir().unwrap();
-        std::env::set_var("OLLAMA_ROUTER_DATA_DIR", temp_dir.path());
+        std::env::set_var("LLM_ROUTER_DATA_DIR", temp_dir.path());
 
         let storage = RequestHistoryStorage::new().unwrap();
 
@@ -359,7 +359,7 @@ mod tests {
         assert_eq!(result.records.len(), 1);
         assert_eq!(result.records[0].model, "llama2");
 
-        std::env::remove_var("OLLAMA_ROUTER_DATA_DIR");
+        std::env::remove_var("LLM_ROUTER_DATA_DIR");
     }
 
     #[tokio::test]
@@ -367,7 +367,7 @@ mod tests {
         let _lock = TEST_LOCK.lock().await;
 
         let temp_dir = tempdir().unwrap();
-        std::env::set_var("OLLAMA_ROUTER_DATA_DIR", temp_dir.path());
+        std::env::set_var("LLM_ROUTER_DATA_DIR", temp_dir.path());
 
         let storage = RequestHistoryStorage::new().unwrap();
 
@@ -392,6 +392,6 @@ mod tests {
         let result = storage.filter_and_paginate(&filter, 3, 2).await.unwrap();
         assert_eq!(result.records.len(), 1);
 
-        std::env::remove_var("OLLAMA_ROUTER_DATA_DIR");
+        std::env::remove_var("LLM_ROUTER_DATA_DIR");
     }
 }

--- a/router/src/logging.rs
+++ b/router/src/logging.rs
@@ -39,7 +39,7 @@ pub fn log_file_path() -> io::Result<PathBuf> {
 }
 
 fn resolve_data_dir() -> io::Result<PathBuf> {
-    if let Ok(dir) = env::var("OLLAMA_ROUTER_DATA_DIR") {
+    if let Ok(dir) = env::var("LLM_ROUTER_DATA_DIR") {
         return Ok(PathBuf::from(dir));
     }
 
@@ -95,22 +95,22 @@ mod tests {
     #[test]
     fn test_resolve_data_dir_uses_env_override() {
         let temp_dir = tempfile::tempdir().unwrap();
-        env::set_var("OLLAMA_ROUTER_DATA_DIR", temp_dir.path());
+        env::set_var("LLM_ROUTER_DATA_DIR", temp_dir.path());
         let dir = resolve_data_dir().unwrap();
         assert_eq!(dir, temp_dir.path());
-        env::remove_var("OLLAMA_ROUTER_DATA_DIR");
+        env::remove_var("LLM_ROUTER_DATA_DIR");
     }
 
     #[test]
     fn test_log_file_path_contains_logs_dir() {
         let temp_dir = tempfile::tempdir().unwrap();
-        env::set_var("OLLAMA_ROUTER_DATA_DIR", temp_dir.path());
+        env::set_var("LLM_ROUTER_DATA_DIR", temp_dir.path());
         let path = log_file_path().unwrap();
         assert!(
             path.ends_with(std::path::Path::new("logs").join(LOG_FILE_NAME)),
             "unexpected log path: {:?}",
             path
         );
-        env::remove_var("OLLAMA_ROUTER_DATA_DIR");
+        env::remove_var("LLM_ROUTER_DATA_DIR");
     }
 }

--- a/router/tests/contract/models_api_test.rs
+++ b/router/tests/contract/models_api_test.rs
@@ -21,7 +21,7 @@ async fn build_app() -> Router {
         uuid::Uuid::new_v4()
     ));
     std::fs::create_dir_all(&temp_dir).unwrap();
-    std::env::set_var("OLLAMA_ROUTER_DATA_DIR", &temp_dir);
+    std::env::set_var("LLM_ROUTER_DATA_DIR", &temp_dir);
 
     let registry = NodeRegistry::new();
     let load_manager = LoadManager::new(registry.clone());
@@ -52,7 +52,7 @@ async fn build_app() -> Router {
 #[tokio::test]
 #[serial]
 async fn test_get_available_models_contract() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let app = build_app().await;
 
     let response = app
@@ -118,7 +118,7 @@ async fn test_get_available_models_contract() {
 #[tokio::test]
 #[serial]
 async fn test_distribute_models_contract() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let app = build_app().await;
 
     // テスト用リクエスト
@@ -174,7 +174,7 @@ async fn test_distribute_models_contract() {
 #[tokio::test]
 #[serial]
 async fn test_get_agent_models_contract() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let app = build_app().await;
 
     // テスト用のノードを登録
@@ -256,7 +256,7 @@ async fn test_get_agent_models_contract() {
 #[tokio::test]
 #[serial]
 async fn test_pull_model_contract() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let app = build_app().await;
 
     // テスト用のノードを登録
@@ -338,7 +338,7 @@ async fn test_pull_model_contract() {
 #[tokio::test]
 #[serial]
 async fn test_get_task_progress_contract() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let app = build_app().await;
 
     // テスト用のノードを登録

--- a/router/tests/contract/test_agent_register_gpu.rs
+++ b/router/tests/contract/test_agent_register_gpu.rs
@@ -22,7 +22,7 @@ async fn build_app() -> Router {
         uuid::Uuid::new_v4()
     ));
     std::fs::create_dir_all(&temp_dir).unwrap();
-    std::env::set_var("OLLAMA_ROUTER_DATA_DIR", &temp_dir);
+    std::env::set_var("LLM_ROUTER_DATA_DIR", &temp_dir);
 
     let registry = NodeRegistry::new();
     let load_manager = LoadManager::new(registry.clone());
@@ -52,7 +52,7 @@ async fn build_app() -> Router {
 #[tokio::test]
 #[serial]
 async fn register_gpu_agent_success() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let app = build_app().await;
 
     let payload = json!({
@@ -117,7 +117,7 @@ async fn register_gpu_agent_success() {
 #[tokio::test]
 #[serial]
 async fn register_gpu_agent_missing_devices_is_rejected() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let app = build_app().await;
 
     let payload = json!({

--- a/router/tests/contract/test_proxy_chat.rs
+++ b/router/tests/contract/test_proxy_chat.rs
@@ -86,7 +86,7 @@ async fn agent_chat_handler(
 #[tokio::test]
 #[serial]
 async fn proxy_chat_end_to_end_success() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     // Arrange: スタブノードとルーターを実ポートで起動
     let node_stub = spawn_agent_stub(AgentStubState {
         expected_model: Some("gpt-oss:20b".to_string()),
@@ -137,7 +137,7 @@ async fn proxy_chat_end_to_end_success() {
 #[tokio::test]
 #[serial]
 async fn proxy_chat_uses_health_check_without_skip_flag() {
-    let _guard = EnvVarGuard::remove("OLLAMA_ROUTER_SKIP_HEALTH_CHECK");
+    let _guard = EnvVarGuard::remove("LLM_ROUTER_SKIP_HEALTH_CHECK");
 
     let node_stub = spawn_agent_stub(AgentStubState {
         expected_model: Some("gpt-oss:20b".to_string()),
@@ -184,7 +184,7 @@ async fn proxy_chat_uses_health_check_without_skip_flag() {
 #[tokio::test]
 #[serial]
 async fn proxy_chat_propagates_upstream_error() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     // Arrange: ノードが404を返すケース
     let node_stub = spawn_agent_stub(AgentStubState {
         expected_model: Some("missing-model".to_string()),

--- a/router/tests/contract/test_proxy_completions.rs
+++ b/router/tests/contract/test_proxy_completions.rs
@@ -96,7 +96,7 @@ async fn agent_tags_handler(State(state): State<Arc<AgentStubState>>) -> impl In
 #[tokio::test]
 #[serial]
 async fn proxy_completions_end_to_end_success() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let agent_stub = spawn_agent_stub(AgentStubState {
         expected_model: Some("gpt-oss:20b".to_string()),
         response: AgentGenerateStubResponse::Success(serde_json::json!({
@@ -135,7 +135,7 @@ async fn proxy_completions_end_to_end_success() {
 #[tokio::test]
 #[serial]
 async fn proxy_completions_propagates_upstream_error() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let agent_stub = spawn_agent_stub(AgentStubState {
         expected_model: Some("missing-model".to_string()),
         response: AgentGenerateStubResponse::Error(

--- a/router/tests/contract/test_proxy_generate.rs
+++ b/router/tests/contract/test_proxy_generate.rs
@@ -64,7 +64,7 @@ async fn agent_generate_handler(
 #[tokio::test]
 #[serial]
 async fn proxy_generate_end_to_end_success() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let node_stub = spawn_agent_stub(AgentStubState {
         expected_model: Some("gpt-oss:20b".to_string()),
         response: AgentGenerateStubResponse::Success(serde_json::json!({
@@ -104,7 +104,7 @@ async fn proxy_generate_end_to_end_success() {
 #[tokio::test]
 #[serial]
 async fn proxy_generate_propagates_upstream_error() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let node_stub = spawn_agent_stub(AgentStubState {
         expected_model: Some("missing-model".to_string()),
         response: AgentGenerateStubResponse::Error(

--- a/router/tests/e2e/agent_flow_test.rs
+++ b/router/tests/e2e/agent_flow_test.rs
@@ -42,7 +42,7 @@ async fn build_app() -> (Router, sqlx::SqlitePool) {
 #[tokio::test]
 async fn test_complete_agent_flow() {
     // ヘルスチェックをスキップ（E2Eテストでは実際のエージェントAPIがない）
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let (app, _db_pool) = build_app().await;
 
     // Step 1: エージェント登録
@@ -171,7 +171,7 @@ async fn test_complete_agent_flow() {
 #[tokio::test]
 async fn test_agent_token_persistence() {
     // ヘルスチェックをスキップ（E2Eテストでは実際のエージェントAPIがない）
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let (app, _db_pool) = build_app().await;
 
     // エージェント登録

--- a/router/tests/e2e_openai_proxy.rs
+++ b/router/tests/e2e_openai_proxy.rs
@@ -94,7 +94,7 @@ async fn agent_generate_handler(
 
 #[tokio::test]
 async fn openai_proxy_end_to_end_updates_dashboard_history() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let node_stub = spawn_agent_stub(AgentStubState {
         chat_response: ChatResponse {
             message: llm_router_common::protocol::ChatMessage {

--- a/router/tests/integration/dashboard_gpu_display.rs
+++ b/router/tests/integration/dashboard_gpu_display.rs
@@ -40,7 +40,7 @@ async fn build_router() -> Router {
 
 #[tokio::test]
 async fn dashboard_agents_include_gpu_devices() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let router = build_router().await;
 
     let payload = json!({

--- a/router/tests/integration/model_info_test.rs
+++ b/router/tests/integration/model_info_test.rs
@@ -101,7 +101,7 @@ async fn test_list_available_models_from_ollama_library() {
 /// T019: 特定ノードのインストール済みモデル一覧を取得
 #[tokio::test]
 async fn test_list_installed_models_on_agent() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let app = build_app().await;
 
     // テスト用ノードを登録
@@ -182,7 +182,7 @@ async fn test_list_installed_models_on_agent() {
 /// T020: 全ノードのモデルマトリックス表示
 #[tokio::test]
 async fn test_model_matrix_view_multiple_agents() {
-    std::env::set_var("OLLAMA_ROUTER_SKIP_HEALTH_CHECK", "1");
+    std::env::set_var("LLM_ROUTER_SKIP_HEALTH_CHECK", "1");
     let app = build_app().await;
 
     // 複数のノードを登録

--- a/router/tests/integration/registry_cleanup.rs
+++ b/router/tests/integration/registry_cleanup.rs
@@ -37,7 +37,7 @@ async fn gpu_less_agents_are_removed_on_startup() {
     fs::create_dir_all(data_dir).unwrap();
     fs::write(&data_file, serde_json::to_string_pretty(&nodes).unwrap()).unwrap();
 
-    std::env::set_var("OLLAMA_ROUTER_DATA_DIR", data_dir);
+    std::env::set_var("LLM_ROUTER_DATA_DIR", data_dir);
 
     // Act: ストレージ付きレジストリを初期化
     let registry = NodeRegistry::with_storage()
@@ -65,5 +65,5 @@ async fn gpu_less_agents_are_removed_on_startup() {
         .map(|list| !list.is_empty())
         .unwrap_or(false)));
 
-    std::env::remove_var("OLLAMA_ROUTER_DATA_DIR");
+    std::env::remove_var("LLM_ROUTER_DATA_DIR");
 }

--- a/router/tests/support/router.rs
+++ b/router/tests/support/router.rs
@@ -34,7 +34,7 @@ pub async fn spawn_test_router() -> TestServer {
     // テスト用に一時ディレクトリを設定
     let temp_dir = std::env::temp_dir().join(format!("or-test-{}", std::process::id()));
     std::fs::create_dir_all(&temp_dir).unwrap();
-    std::env::set_var("OLLAMA_ROUTER_DATA_DIR", &temp_dir);
+    std::env::set_var("LLM_ROUTER_DATA_DIR", &temp_dir);
 
     let registry = NodeRegistry::new();
     let load_manager = LoadManager::new(registry.clone());

--- a/specs/SPEC-94621a1f/spec.md
+++ b/specs/SPEC-94621a1f/spec.md
@@ -76,7 +76,7 @@
 
 ### FR-006: 環境変数／設定パネルによる上書き
 
-- ノードのエントリーポイントは `ROUTER_URL`, `OLLAMA_PORT`, `AGENT_HEARTBEAT_INTERVAL_SECS` などの環境変数で設定を上書きできる。
+- ノードのエントリーポイントは `ROUTER_URL`, `LLM_PORT`, `AGENT_HEARTBEAT_INTERVAL_SECS` などの環境変数で設定を上書きできる。
 - 同じ設定項目はローカル設定パネルからも編集でき、`~/.ollama-router/agent-settings.json` に保存され、環境変数が未指定のときに適用される。
 
 ## 非機能要件


### PR DESCRIPTION
## Summary

- fix(test): Apple Silicon capability score factor追加（CI失敗修正）
- refactor!: 環境変数を `OLLAMA_*` から `LLM_*` にリネーム

## BREAKING CHANGE

全ての環境変数名が変更されました：
- `OLLAMA_ROUTER_URL` → `LLM_ROUTER_URL`
- `OLLAMA_NODE_PORT` → `LLM_NODE_PORT`
- `OLLAMA_MODELS_DIR` → `LLM_MODELS_DIR`
- その他（詳細はコミットログ参照）

## Test plan

- [x] `cargo fmt --check` 合格
- [x] `cargo clippy -- -D warnings` 合格
- [x] `cargo test` 合格
- [x] `markdownlint` 合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)