### PR TITLE
fix(ci): create coverage-rust directory before lcov output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
           cargo install cargo-llvm-cov --locked
       - name: Run coverage
         run: |
+          mkdir -p coverage-rust
           cargo llvm-cov --all-features --workspace --lcov --output-path coverage-rust/lcov.info
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- カバレッジレポート出力前に`coverage-rust`ディレクトリを作成

## Background
Coverage (Rust) CIジョブが失敗していた原因:
- `cargo llvm-cov`が`coverage-rust/lcov.info`へ出力しようとした際、ディレクトリが存在せずエラー

## Fix
- `mkdir -p coverage-rust`を追加してディレクトリを事前に作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)