### PR TITLE
fix(build): rename OLLAMA_NODE_TESTING to LLM_NODE_TESTING

### DIFF
--- a/node/src/system/gpu_detector.mm
+++ b/node/src/system/gpu_detector.mm
@@ -141,7 +141,7 @@ std::vector<GpuDevice> GpuDetector::detectRocm() {
     return std::vector<GpuDevice>();
 }
 
-#ifdef OLLAMA_NODE_TESTING
+#ifdef LLM_NODE_TESTING
 void GpuDetector::setDetectedDevicesForTest(std::vector<GpuDevice> devices) {
     detected_devices_ = std::move(devices);
 }

--- a/node/tests/integration/CMakeLists.txt
+++ b/node/tests/integration/CMakeLists.txt
@@ -59,7 +59,7 @@ target_include_directories(llm-node-integration-tests
 
 target_compile_definitions(llm-node-integration-tests
     PRIVATE
-        OLLAMA_NODE_TESTING=1
+        LLM_NODE_TESTING=1
 )
 
 add_test(

--- a/node/tests/unit/CMakeLists.txt
+++ b/node/tests/unit/CMakeLists.txt
@@ -61,7 +61,7 @@ target_include_directories(llm-node-unit-tests
 
 target_compile_definitions(llm-node-unit-tests
     PRIVATE
-        OLLAMA_NODE_TESTING=1
+        LLM_NODE_TESTING=1
 )
 
 add_test(


### PR DESCRIPTION
## Summary
- C++テストビルドで使用するマクロ名を`OLLAMA_NODE_TESTING`から`LLM_NODE_TESTING`にリネーム

## Background
C++ Node (build & test) CIジョブが失敗していた原因:
- ヘッダーファイル (`gpu_detector.h`) は `LLM_NODE_TESTING` を期待
- CMakeLists.txt は `OLLAMA_NODE_TESTING` を定義
- マクロ名の不一致により `setDetectedDevicesForTest` メソッドが見つからずコンパイルエラー

## Changes
- `node/tests/unit/CMakeLists.txt`: `OLLAMA_NODE_TESTING` → `LLM_NODE_TESTING`
- `node/tests/integration/CMakeLists.txt`: `OLLAMA_NODE_TESTING` → `LLM_NODE_TESTING`
- `node/src/system/gpu_detector.mm`: `OLLAMA_NODE_TESTING` → `LLM_NODE_TESTING`

🤖 Generated with [Claude Code](https://claude.com/claude-code)