### PR TITLE
fix(ci): add libcurl4-openssl-dev for C++ node build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libssl-dev clang-tidy cppcheck
+          sudo apt-get install -y build-essential cmake libssl-dev libcurl4-openssl-dev clang-tidy cppcheck
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -125,7 +125,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libssl-dev gcovr
+          sudo apt-get install -y build-essential cmake libssl-dev libcurl4-openssl-dev gcovr
       - uses: actions/setup-node@v4
         with:
           node-version: '20'


### PR DESCRIPTION
## Summary

- C++ Nodeビルドジョブに`libcurl4-openssl-dev`を追加
- llama.cppのリモートモデルダウンロード機能に必要な依存関係
- `cpp`ジョブと`coverage-cpp`ジョブの両方を修正

## Problem

llama.cppのビルド時に以下のエラーが発生していた:
```
CMake Error at third_party/llama.cpp/common/CMakeLists.txt:91 (message):
  Could NOT find CURL.  Hint: to disable this feature, set -DLLAMA_CURL=OFF
```

## Changes

- `.github/workflows/ci.yml`: 2箇所の`apt-get install`に`libcurl4-openssl-dev`を追加

## Test plan

- [x] CI C++ Node (build & test)ジョブがパスすることを確認
- [x] CI Coverage (C++)ジョブがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI ビルドプロセスの依存パッケージを更新しました。これにより、ビルドの安定性と互換性が向上します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->