### PR TITLE
fix(test): correct namespace from ollama_node to llm_node

### DIFF
--- a/node/tests/unit/inference_engine_test.cpp
+++ b/node/tests/unit/inference_engine_test.cpp
@@ -5,10 +5,10 @@
 using namespace llm_node;
 
 // テスト専用ヘルパー（inference_engine.cppで定義）
-namespace ollama_node {
+namespace llm_node {
 std::string extractGptOssFinalMessageForTest(const std::string& output);
 }
-using ollama_node::extractGptOssFinalMessageForTest;
+using llm_node::extractGptOssFinalMessageForTest;
 
 TEST(InferenceEngineTest, GeneratesChatFromLastUserMessage) {
     InferenceEngine engine;


### PR DESCRIPTION
## Summary

- C++テストの namespace を `ollama_node` から `llm_node` に修正
- リンカーエラー `undefined reference to ollama_node::extractGptOssFinalMessageForTest` を解決

## Problem

リファクタリング時に `inference_engine_test.cpp` の namespace 参照が更新されていなかった。

## Changes

- `node/tests/unit/inference_engine_test.cpp`: namespace 宣言を `llm_node` に修正

## Test plan

- [x] CI C++ Node (build & test)ジョブがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チューアシ改善（内部的）**
  * テスト用の内部コードを整理し、より良い構成に変更しました。この変更がユーザーへの機能や動作に影響することはありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->