### PR TITLE
fix(test): add required model field to /pull test request

### DIFF
--- a/node/tests/integration/node_endpoints_test.cpp
+++ b/node/tests/integration/node_endpoints_test.cpp
@@ -19,7 +19,7 @@ TEST(NodeEndpointsTest, PullAndHealth) {
     server.start();
 
     httplib::Client cli("127.0.0.1", 18088);
-    auto pull = cli.Post("/pull", "{}", "application/json");
+    auto pull = cli.Post("/pull", R"({"model":"test-model"})", "application/json");
     ASSERT_TRUE(pull);
     EXPECT_EQ(pull->status, 200);
     EXPECT_EQ(pull->get_header_value("Content-Type"), "application/json");


### PR DESCRIPTION
## Summary

- `NodeEndpointsTest.PullAndHealth`テストに必須の`model`フィールドを追加
- `/pull`エンドポイントが400エラーを返していた問題を修正

## Problem

テストが空のJSON `{}`を送信していたが、`/pull`エンドポイントは`model`フィールドを必須としている。

## Changes

- `node/tests/integration/node_endpoints_test.cpp`: `/pull`リクエストに`{"model":"test-model"}`を追加

## Test plan

- [x] CI C++ Node (build & test)ジョブがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**テスト**
* 内部テストケースを更新しました

---

注：本変更はエンドユーザーに直接の影響を与えません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->