### PR TITLE
docs(readme): add CLI reference section with all options

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -59,6 +59,61 @@ cargo build --release -p llm-router
 Windows 10以降およびmacOS 12以降では、システムトレイにアイコンが表示されます。
 ダブルクリックでダッシュボードを開きます。Docker/LinuxではCLIプロセスとして動作します。
 
+### CLI リファレンス（Linuxのみ）
+
+> **注意**: CLIサブコマンド（`user`, `model`）はLinuxでのみ利用可能です。
+> Windows/macOSではシステムトレイモードで起動するため、CLIオプションは無視されます。
+
+**基本オプション:**
+
+```bash
+llm-router --help                    # ヘルプ表示
+llm-router --version                 # バージョン表示
+llm-router --preload-model <spec>    # 起動時にHFモデルをプリロード（複数指定可）
+                                     # 形式: repo:filename または repo/filename
+```
+
+**ユーザー管理コマンド:**
+
+```bash
+llm-router user list                           # ユーザー一覧表示
+llm-router user add <username> -p <password>   # ユーザー追加（パスワード8文字以上）
+llm-router user delete <username>              # ユーザー削除
+```
+
+**モデル管理コマンド:**
+
+```bash
+# HF GGUFカタログ表示
+llm-router model list [OPTIONS]
+  --router <URL>      # ルーターURL（デフォルト: http://127.0.0.1:8080）
+  --search <QUERY>    # 検索クエリ
+  --limit <N>         # 取得件数（デフォルト: 20）
+  --offset <N>        # オフセット（デフォルト: 0）
+  --format <FORMAT>   # 出力形式: json | table（デフォルト: table）
+
+# HF GGUFモデル登録
+llm-router model add <REPO> -f <FILE> [--router <URL>]
+  # 例: llm-router model add TheBloke/Llama-2-7B-GGUF -f llama-2-7b.Q4_K_M.gguf
+
+# ノードへモデルダウンロード指示
+llm-router model download <NAME> --all [--router <URL>]        # 全ノードへ配布
+llm-router model download <NAME> --node <UUID> [--router <URL>] # 特定ノードへ配布
+```
+
+**ヘルプ出力に含まれる環境変数:**
+
+```
+ENVIRONMENT VARIABLES:
+    LLM_ROUTER_HOST              Bind address (default: 0.0.0.0)
+    LLM_ROUTER_PORT              Listen port (default: 8080)
+    LLM_ROUTER_LOG_LEVEL         Log level (default: info)
+    LLM_ROUTER_DATABASE_URL      Database URL
+    LLM_ROUTER_JWT_SECRET        JWT signing key (auto-generated if not set)
+    LLM_ROUTER_ADMIN_USERNAME    Initial admin username (default: admin)
+    LLM_ROUTER_ADMIN_PASSWORD    Initial admin password (required on first run)
+```
+
 ### ノード (C++)
 
 **前提条件:**

--- a/README.md
+++ b/README.md
@@ -64,6 +64,61 @@ cargo build --release -p llm-router
 On Windows 10+ and macOS 12+, the router displays a system tray icon.
 Double-click to open the dashboard. Docker/Linux runs as a headless CLI process.
 
+### CLI Reference (Linux only)
+
+> **Note**: CLI subcommands (`user`, `model`) are only available on Linux.
+> On Windows/macOS, the application starts in system tray mode and CLI options are ignored.
+
+**Basic Options:**
+
+```bash
+llm-router --help                    # Show help
+llm-router --version                 # Show version
+llm-router --preload-model <spec>    # Preload HF model at startup (can be specified multiple times)
+                                     # Format: repo:filename or repo/filename
+```
+
+**User Management Commands:**
+
+```bash
+llm-router user list                           # List all users
+llm-router user add <username> -p <password>   # Add user (password min 8 chars)
+llm-router user delete <username>              # Delete user
+```
+
+**Model Management Commands:**
+
+```bash
+# List HF GGUF catalog
+llm-router model list [OPTIONS]
+  --router <URL>      # Router URL (default: http://127.0.0.1:8080)
+  --search <QUERY>    # Search query
+  --limit <N>         # Number of results (default: 20)
+  --offset <N>        # Offset (default: 0)
+  --format <FORMAT>   # Output format: json | table (default: table)
+
+# Register HF GGUF model
+llm-router model add <REPO> -f <FILE> [--router <URL>]
+  # Example: llm-router model add TheBloke/Llama-2-7B-GGUF -f llama-2-7b.Q4_K_M.gguf
+
+# Trigger model download to nodes
+llm-router model download <NAME> --all [--router <URL>]         # Distribute to all nodes
+llm-router model download <NAME> --node <UUID> [--router <URL>] # Distribute to specific node
+```
+
+**Environment Variables (shown in --help output):**
+
+```
+ENVIRONMENT VARIABLES:
+    LLM_ROUTER_HOST              Bind address (default: 0.0.0.0)
+    LLM_ROUTER_PORT              Listen port (default: 8080)
+    LLM_ROUTER_LOG_LEVEL         Log level (default: info)
+    LLM_ROUTER_DATABASE_URL      Database URL
+    LLM_ROUTER_JWT_SECRET        JWT signing key (auto-generated if not set)
+    LLM_ROUTER_ADMIN_USERNAME    Initial admin username (default: admin)
+    LLM_ROUTER_ADMIN_PASSWORD    Initial admin password (required on first run)
+```
+
 ### Node (C++)
 
 **Prerequisites:**


### PR DESCRIPTION
## Summary

- Add comprehensive CLI reference section to both README.md and README.ja.md
- Document `--help`, `--version`, `--preload-model` options
- Add `user` management commands (list, add, delete)
- Add `model` management commands (list, add, download) with all options
- Include environment variables shown in `--help` output
- Note platform limitation: CLI subcommands only available on Linux

## Test plan

- [x] markdownlint passes on both README files
- [x] All existing tests pass
- [x] commitlint validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)