### PR TITLE
fix(models)!: unify model IDs to filename-based format

### DIFF
--- a/common/src/protocol.rs
+++ b/common/src/protocol.rs
@@ -263,7 +263,7 @@ mod tests {
             gpu_capability_score: None,
             active_requests: 3,
             average_response_time_ms: Some(123.4),
-            loaded_models: vec!["gpt-oss:20b".to_string()],
+            loaded_models: vec!["gpt-oss-20b".to_string()],
             loaded_embedding_models: vec!["nomic-embed-text-v1.5".to_string()],
             initializing: true,
             ready_models: Some((1, 2)),

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -234,7 +234,7 @@ mod tests {
             custom_name: Some("Custom".to_string()),
             tags: vec!["primary".to_string()],
             notes: Some("memo".to_string()),
-            loaded_models: vec!["gpt-oss:20b".to_string()],
+            loaded_models: vec!["gpt-oss-20b".to_string()],
             loaded_embedding_models: vec!["nomic-embed-text-v1.5".to_string()],
             gpu_devices: vec![GpuDeviceInfo {
                 model: "NVIDIA RTX 4090".to_string(),

--- a/router/src/api/health.rs
+++ b/router/src/api/health.rs
@@ -130,7 +130,7 @@ mod tests {
             gpu_capability_score: None,
             active_requests: 3,
             average_response_time_ms: Some(110.0),
-            loaded_models: vec!["gpt-oss:20b".into()],
+            loaded_models: vec!["gpt-oss-20b".into()],
             loaded_embedding_models: vec![],
             initializing: false,
             ready_models: Some((1, 1)),
@@ -142,7 +142,7 @@ mod tests {
         // ノードが更新されたことを確認
         let agent = state.registry.get(register_response.node_id).await.unwrap();
         assert_eq!(agent.status, llm_router_common::types::NodeStatus::Online);
-        assert_eq!(agent.loaded_models, vec!["gpt-oss:20b"]);
+        assert_eq!(agent.loaded_models, vec!["gpt-oss-20b"]);
     }
 
     #[tokio::test]

--- a/router/src/api/openai.rs
+++ b/router/src/api/openai.rs
@@ -1531,12 +1531,12 @@ mod tests {
     #[serial]
     async fn non_prefixed_model_stays_on_local_path() {
         let state = create_local_state().await;
-        let payload = json!({"model":"gpt-oss:20b","messages":[]});
+        let payload = json!({"model":"gpt-oss-20b","messages":[]});
         let res = proxy_openai_post(
             &state,
             payload,
             "/v1/chat/completions",
-            "gpt-oss:20b".into(),
+            "gpt-oss-20b".into(),
             false,
             RequestType::Chat,
         )

--- a/router/src/db/mod.rs
+++ b/router/src/db/mod.rs
@@ -400,7 +400,7 @@ mod tests {
             custom_name: Some("Updated".into()),
             tags: vec!["primary".into()],
             notes: None,
-            loaded_models: vec!["gpt-oss:7b".into()],
+            loaded_models: vec!["gpt-oss-7b".into()],
             loaded_embedding_models: Vec::new(),
             gpu_devices: vec![GpuDeviceInfo {
                 model: "Test GPU".to_string(),

--- a/router/src/models/gpu_selector.rs
+++ b/router/src/models/gpu_selector.rs
@@ -5,10 +5,10 @@
 /// GPUメモリに基づいて最適なモデルを選択
 ///
 /// # 選択ルール
-/// - 16GB以上: gpt-oss:20b
-/// - 8GB以上: gpt-oss:7b
-/// - 4.5GB以上: gpt-oss:3b
-/// - 4.5GB未満: gpt-oss:1b
+/// - 16GB以上: gpt-oss-20b
+/// - 8GB以上: gpt-oss-7b
+/// - 4.5GB以上: gpt-oss-3b
+/// - 4.5GB未満: gpt-oss-1b
 ///
 /// # Arguments
 /// * `gpu_memory` - GPUメモリ容量（バイト単位）
@@ -21,13 +21,13 @@ pub fn select_model_by_gpu_memory(gpu_memory: u64) -> String {
     const GB_4_5: u64 = 4_500_000_000;
 
     if gpu_memory >= GB_16 {
-        "gpt-oss:20b".to_string()
+        "gpt-oss-20b".to_string()
     } else if gpu_memory >= GB_8 {
-        "gpt-oss:7b".to_string()
+        "gpt-oss-7b".to_string()
     } else if gpu_memory >= GB_4_5 {
-        "gpt-oss:3b".to_string()
+        "gpt-oss-3b".to_string()
     } else {
-        "gpt-oss:1b".to_string()
+        "gpt-oss-1b".to_string()
     }
 }
 
@@ -37,41 +37,41 @@ mod tests {
 
     #[test]
     fn test_16gb_selects_20b() {
-        assert_eq!(select_model_by_gpu_memory(16_000_000_000), "gpt-oss:20b");
+        assert_eq!(select_model_by_gpu_memory(16_000_000_000), "gpt-oss-20b");
     }
 
     #[test]
     fn test_24gb_selects_20b() {
-        assert_eq!(select_model_by_gpu_memory(24_000_000_000), "gpt-oss:20b");
+        assert_eq!(select_model_by_gpu_memory(24_000_000_000), "gpt-oss-20b");
     }
 
     #[test]
     fn test_8gb_selects_7b() {
-        assert_eq!(select_model_by_gpu_memory(8_000_000_000), "gpt-oss:7b");
+        assert_eq!(select_model_by_gpu_memory(8_000_000_000), "gpt-oss-7b");
     }
 
     #[test]
     fn test_12gb_selects_7b() {
-        assert_eq!(select_model_by_gpu_memory(12_000_000_000), "gpt-oss:7b");
+        assert_eq!(select_model_by_gpu_memory(12_000_000_000), "gpt-oss-7b");
     }
 
     #[test]
     fn test_4_5gb_selects_3b() {
-        assert_eq!(select_model_by_gpu_memory(4_500_000_000), "gpt-oss:3b");
+        assert_eq!(select_model_by_gpu_memory(4_500_000_000), "gpt-oss-3b");
     }
 
     #[test]
     fn test_6gb_selects_3b() {
-        assert_eq!(select_model_by_gpu_memory(6_000_000_000), "gpt-oss:3b");
+        assert_eq!(select_model_by_gpu_memory(6_000_000_000), "gpt-oss-3b");
     }
 
     #[test]
     fn test_2gb_selects_1b() {
-        assert_eq!(select_model_by_gpu_memory(2_000_000_000), "gpt-oss:1b");
+        assert_eq!(select_model_by_gpu_memory(2_000_000_000), "gpt-oss-1b");
     }
 
     #[test]
     fn test_4gb_selects_1b() {
-        assert_eq!(select_model_by_gpu_memory(4_000_000_000), "gpt-oss:1b");
+        assert_eq!(select_model_by_gpu_memory(4_000_000_000), "gpt-oss-1b");
     }
 }

--- a/router/src/registry/mod.rs
+++ b/router/src/registry/mod.rs
@@ -699,8 +699,8 @@ mod tests {
             .update_last_seen(
                 node_id,
                 Some(vec![
-                    " gpt-oss:20b ".into(),
-                    "gpt-oss:20b".into(),
+                    " gpt-oss-20b ".into(),
+                    "gpt-oss-20b".into(),
                     "".into(),
                     "phi-3".into(),
                 ]),
@@ -715,7 +715,7 @@ mod tests {
             .unwrap();
 
         let node = registry.get(node_id).await.unwrap();
-        assert_eq!(node.loaded_models, vec!["gpt-oss:20b", "phi-3"]);
+        assert_eq!(node.loaded_models, vec!["gpt-oss-20b", "phi-3"]);
     }
 
     #[test]

--- a/router/src/tasks/mod.rs
+++ b/router/src/tasks/mod.rs
@@ -132,10 +132,10 @@ mod tests {
         let manager = DownloadTaskManager::new();
         let node_id = Uuid::new_v4();
 
-        let task = manager.create_task(node_id, "gpt-oss:7b".to_string()).await;
+        let task = manager.create_task(node_id, "gpt-oss-7b".to_string()).await;
 
         assert_eq!(task.node_id, node_id);
-        assert_eq!(task.model_name, "gpt-oss:7b");
+        assert_eq!(task.model_name, "gpt-oss-7b");
         assert_eq!(task.status, DownloadStatus::Pending);
 
         // タスクが取得できることを確認

--- a/router/tests/openai_proxy.rs
+++ b/router/tests/openai_proxy.rs
@@ -64,8 +64,8 @@ async fn build_state_with_mock(mock: &MockServer) -> (AppState, String) {
         .update_last_seen(
             node_id,
             Some(vec![
-                "gpt-oss:20b".to_string(),
-                "gpt-oss:120b".to_string(),
+                "gpt-oss-20b".to_string(),
+                "gpt-oss-120b".to_string(),
                 "test-model".to_string(),
             ]),
             None, // loaded_embedding_models
@@ -435,7 +435,7 @@ async fn test_openai_models_list_success() {
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "object": "list",
             "data": [{
-                "id": "gpt-oss:20b",
+                "id": "gpt-oss-20b",
                 "object": "model",
                 "owned_by": "runtime"
             }]
@@ -479,9 +479,9 @@ async fn test_openai_model_detail_success() {
     let mock_server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/models/gpt-oss:20b"))
+        .and(path("/v1/models/gpt-oss-20b"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "id": "gpt-oss:20b",
+            "id": "gpt-oss-20b",
             "object": "model",
             "owned_by": "runtime"
         })))
@@ -495,7 +495,7 @@ async fn test_openai_model_detail_success() {
         .oneshot(
             axum::http::Request::builder()
                 .method("GET")
-                .uri("/v1/models/gpt-oss:20b")
+                .uri("/v1/models/gpt-oss-20b")
                 .header("Authorization", format!("Bearer {}", api_key))
                 .body(axum::body::Body::empty())
                 .unwrap(),

--- a/router/tests/unit/gpu_model_selector_test.rs
+++ b/router/tests/unit/gpu_model_selector_test.rs
@@ -6,36 +6,36 @@
 mod tests {
     use llm_router::models::gpu_selector::select_model_by_gpu_memory;
 
-    /// T021: 16GB GPUには gpt-oss:20b を選択
+    /// T021: 16GB GPUには gpt-oss-20b を選択
     #[test]
     fn test_select_model_by_gpu_memory_16gb() {
         let gpu_memory: u64 = 16_000_000_000;
         let model = select_model_by_gpu_memory(gpu_memory);
-        assert_eq!(model, "gpt-oss:20b", "16GB GPU should select gpt-oss:20b");
+        assert_eq!(model, "gpt-oss-20b", "16GB GPU should select gpt-oss-20b");
     }
 
-    /// T021: 8GB GPUには gpt-oss:7b を選択
+    /// T021: 8GB GPUには gpt-oss-7b を選択
     #[test]
     fn test_select_model_by_gpu_memory_8gb() {
         let gpu_memory: u64 = 8_000_000_000;
         let model = select_model_by_gpu_memory(gpu_memory);
-        assert_eq!(model, "gpt-oss:7b", "8GB GPU should select gpt-oss:7b");
+        assert_eq!(model, "gpt-oss-7b", "8GB GPU should select gpt-oss-7b");
     }
 
-    /// T021: 4.5GB GPUには gpt-oss:3b を選択
+    /// T021: 4.5GB GPUには gpt-oss-3b を選択
     #[test]
     fn test_select_model_by_gpu_memory_4_5gb() {
         let gpu_memory: u64 = 4_500_000_000;
         let model = select_model_by_gpu_memory(gpu_memory);
-        assert_eq!(model, "gpt-oss:3b", "4.5GB GPU should select gpt-oss:3b");
+        assert_eq!(model, "gpt-oss-3b", "4.5GB GPU should select gpt-oss-3b");
     }
 
-    /// T021: 4.5GB未満のGPUには gpt-oss:1b を選択
+    /// T021: 4.5GB未満のGPUには gpt-oss-1b を選択
     #[test]
     fn test_select_model_by_gpu_memory_small() {
         let gpu_memory: u64 = 2_000_000_000;
         let model = select_model_by_gpu_memory(gpu_memory);
-        assert_eq!(model, "gpt-oss:1b", "Small GPU should select gpt-oss:1b");
+        assert_eq!(model, "gpt-oss-1b", "Small GPU should select gpt-oss-1b");
     }
 
     /// T021: 境界値テスト - ちょうど16GB
@@ -43,7 +43,7 @@ mod tests {
     fn test_select_model_boundary_16gb() {
         let gpu_memory: u64 = 16_000_000_000;
         let model = select_model_by_gpu_memory(gpu_memory);
-        assert_eq!(model, "gpt-oss:20b");
+        assert_eq!(model, "gpt-oss-20b");
     }
 
     /// T021: 境界値テスト - ちょうど8GB
@@ -51,7 +51,7 @@ mod tests {
     fn test_select_model_boundary_8gb() {
         let gpu_memory: u64 = 8_000_000_000;
         let model = select_model_by_gpu_memory(gpu_memory);
-        assert_eq!(model, "gpt-oss:7b");
+        assert_eq!(model, "gpt-oss-7b");
     }
 
     /// T021: 境界値テスト - ちょうど4.5GB
@@ -59,7 +59,7 @@ mod tests {
     fn test_select_model_boundary_4_5gb() {
         let gpu_memory: u64 = 4_500_000_000;
         let model = select_model_by_gpu_memory(gpu_memory);
-        assert_eq!(model, "gpt-oss:3b");
+        assert_eq!(model, "gpt-oss-3b");
     }
 
     /// T021: 非常に大きなGPUメモリ (24GB)
@@ -67,6 +67,6 @@ mod tests {
     fn test_select_model_very_large_gpu() {
         let gpu_memory: u64 = 24_000_000_000;
         let model = select_model_by_gpu_memory(gpu_memory);
-        assert_eq!(model, "gpt-oss:20b");
+        assert_eq!(model, "gpt-oss-20b");
     }
 }

--- a/router/tests/unit/model_repository_test.rs
+++ b/router/tests/unit/model_repository_test.rs
@@ -12,7 +12,7 @@ mod tests {
     async fn test_task_lifecycle() {
         let manager = DownloadTaskManager::new();
         let node_id = Uuid::new_v4();
-        let model_name = "gpt-oss:20b".to_string();
+        let model_name = "gpt-oss-20b".to_string();
 
         // 1. タスク作成
         let task = manager.create_task(node_id, model_name.clone()).await;
@@ -85,9 +85,9 @@ mod tests {
         let agent2 = Uuid::new_v4();
 
         // 2つのタスクを作成
-        let task1 = manager.create_task(agent1, "gpt-oss:20b".to_string()).await;
+        let task1 = manager.create_task(agent1, "gpt-oss-20b".to_string()).await;
         let task2 = manager
-            .create_task(agent2, "gpt-oss:120b".to_string())
+            .create_task(agent2, "gpt-oss-120b".to_string())
             .await;
 
         // 両方のタスクが取得できることを確認
@@ -107,9 +107,9 @@ mod tests {
         let agent2 = Uuid::new_v4();
 
         // agent1に2つのタスク
-        manager.create_task(agent1, "gpt-oss:20b".to_string()).await;
+        manager.create_task(agent1, "gpt-oss-20b".to_string()).await;
         manager
-            .create_task(agent1, "gpt-oss:120b".to_string())
+            .create_task(agent1, "gpt-oss-120b".to_string())
             .await;
 
         // agent2に1つのタスク


### PR DESCRIPTION
## Summary

- PlaygroundでモデルID `gpt-oss:20b` が認識されない問題を修正
- Ollama形式のモデルID（コロン区切り）を廃止し、ファイル名ベース形式（ハイフン区切り）に統一
- `extract_name_and_tag()` 関数を簡素化し、コード量を54行削減

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `router/src/registry/models.rs` | `extract_name_and_tag()` をファイル名ベース形式に変更、未使用関数削除 |
| `router/src/models/gpu_selector.rs` | 戻り値を `gpt-oss-20b` 形式に統一 |
| テストファイル (11ファイル) | モデルIDを新形式に更新 |

## Breaking Change

`/v1/models` APIのモデルIDが `gpt-oss:20b` から `gpt-oss-20b` 形式に変更されます。
既存のモデル設定は再登録が必要な場合があります。

## Test plan

- [x] `cargo test` - 全186+テスト合格
- [x] `make quality-checks` - 全チェック合格
- [x] clippy warnings なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)