### PR TITLE
docs(readme): README.ja のモデル削除API表記を統一

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -164,7 +164,7 @@ LLM_ROUTER_URL=http://localhost:8080 ./node/build/llm-node
 - GET `/v0/models/available`（例: `?source=hf`）
 - POST `/v0/models/register`
 - GET `/v0/models/registered`
-- DELETE `/v0/models/:model_name`
+- DELETE `/v0/models/*model_name`
 - POST `/v0/models/discover-gguf`
 - POST `/v0/models/convert`
 - GET `/v0/models/convert`


### PR DESCRIPTION
README.ja.md のモデル削除エンドポイント表記を、実装/README.md/SPECと同じ `DELETE /v0/models/*model_name` に統一します。