### PR TITLE
fix(api): エラーレスポンスから内部ネットワーク情報を除去

### DIFF
--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -93,6 +93,36 @@ pub enum RouterError {
     Authorization(String),
 }
 
+impl RouterError {
+    /// Returns a safe error message for external clients.
+    ///
+    /// This method returns a generic error message that does not expose
+    /// internal implementation details such as IP addresses, port numbers,
+    /// or internal service names. Use this for HTTP responses to external clients.
+    ///
+    /// For debugging purposes, use the `Display` implementation (`to_string()`)
+    /// which includes full error details - but only in server logs.
+    pub fn external_message(&self) -> &'static str {
+        match self {
+            Self::Common(_) => "Request error",
+            Self::NodeNotFound(_) => "Node not found",
+            Self::NoNodesAvailable => "No available nodes",
+            Self::Database(_) => "Database error",
+            Self::Http(_) => "Backend service unavailable",
+            Self::Timeout(_) => "Request timeout",
+            Self::ServiceUnavailable(_) => "Service temporarily unavailable",
+            Self::Internal(_) => "Internal server error",
+            Self::NodeOffline(_) => "Node offline",
+            Self::InvalidModelName(_) => "Invalid model name",
+            Self::InsufficientStorage(_) => "Insufficient storage",
+            Self::PasswordHash(_) => "Authentication error",
+            Self::Jwt(_) => "Authentication error",
+            Self::Authentication(_) => "Authentication failed",
+            Self::Authorization(_) => "Access denied",
+        }
+    }
+}
+
 /// Node error type
 #[derive(Debug, Error)]
 pub enum NodeError {

--- a/router/tests/contract/test_node_register_gpu.rs
+++ b/router/tests/contract/test_node_register_gpu.rs
@@ -182,8 +182,6 @@ async fn register_gpu_node_missing_devices_is_rejected() {
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     let body = to_bytes(response.into_body(), 1024).await.unwrap();
     let error: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(
-        error["error"],
-        "Validation error: GPU hardware is required for node registration. No GPU devices detected in gpu_devices array."
-    );
+    // Security: external_message() returns generic error to prevent information disclosure
+    assert_eq!(error["error"], "Request error");
 }


### PR DESCRIPTION
## Summary

- 外部クライアントへのエラーレスポンスに内部IPアドレスとポート番号が露出していたセキュリティ問題を修正
- OWASP: Sensitive Data Exposure / Security Misconfiguration 対策

## Changes

- `RouterError::external_message()` メソッドを追加し、外部向けの汎用的なエラーメッセージを返すよう実装
- `AppError::into_response()` で `external_message()` を使用するよう変更
- ノードヘルスチェック失敗時のエラーから内部URLを除去
- 関連するテストの期待値を更新

## Before (Vulnerable)

```
バックエンドLLM | ❌ 127.0.0.1:11435 に接続できない
```

## After (Safe)

```
Backend service unavailable
```

## Test plan

- [x] `cargo fmt --check` passed
- [x] `cargo clippy -- -D warnings` passed
- [x] `cargo test` passed (64 tests)
- [x] `make quality-checks` passed
- [x] `make openai-tests` passed (8 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * エラーレスポンスの安全性を向上させました。内部システム情報の露出を防ぐため、ノード登録時のエラーメッセージを一般的なメッセージに統一しました。

* **テスト**
  * エラーハンドリングの変更に対応するため、テスト期待値を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->