### PR TITLE
chore: ignore node debug build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ cmake_install.cmake
 compile_commands.json
 Makefile
 *.cmake
+node/build-debug/
+node/build-debug-onnx/
+node/build-debug-onnx-cpu/
 
 # Environment variables
 .env


### PR DESCRIPTION
- Add node/build-debug*, node/build-debug-onnx*, node/build-debug-onnx-cpu to .gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Git ignore パターンを更新し、Node.js のビルド出力ディレクトリを除外対象に追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->