### PR TITLE
ci: skip build/test when no c++/rust changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
 
   rust:
     name: Rust (fmt/clippy/test) ${{ matrix.os }}
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -132,6 +134,8 @@ jobs:
 
   coverage-rust:
     name: Coverage (Rust)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,30 @@ on:
       - develop
 
 jobs:
+  # パス変更検出（Rustジョブの条件付き実行用）
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'router/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/lint.yml'
+
   rust-lint:
     # 要件: FR-004
     # 目的: Rust lintチェック（fmt, clippy）
     name: Rust Format & Clippy
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,13 @@ on:
       - develop
 
 jobs:
-  # パス変更検出（C++ジョブの条件付き実行用）
+  # パス変更検出（C++/Rustジョブの条件付き実行用）
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
       cpp: ${{ steps.filter.outputs.cpp }}
+      rust: ${{ steps.filter.outputs.rust }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -27,6 +28,11 @@ jobs:
               - 'node/**'
               - 'package.json'
               - '.github/actions/setup-cpp/**'
+              - '.github/workflows/test.yml'
+            rust:
+              - 'router/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
               - '.github/workflows/test.yml'
 
   tasks-check:
@@ -51,6 +57,8 @@ jobs:
     # 要件: FR-003
     # 目的: Rustテストを実行（複数OS）
     name: Rust Tests (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -76,6 +84,8 @@ jobs:
     # 要件: OpenAI互換APIの回帰テスト
     # 目的: OpenAI APIとの互換性を確認
     name: OpenAI API Compatibility Tests
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- C++/Rust関連のCIジョブを変更依存型に修正
- 変更がない場合はこれらのジョブをスキップ
- ブランチ保護の必須チェックから削除済み

## Changes
- **ci.yml**: `rust`, `coverage-rust` ジョブに変更条件を追加
- **test.yml**: `rust-test`, `openai-proxy-tests` ジョブに変更条件を追加  
- **lint.yml**: `changes` ジョブを追加、`rust-lint` ジョブに変更条件を追加

## Test plan
- [ ] PRのCIで、Rust関連ジョブがスキップされることを確認
- [ ] Tasks Completion Check, Commit Message Lint, Markdown Lint のみが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)