### PR TITLE
refactor: update remaining llm-router references to llmlb

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
       "prerelease": "alpha"
     }
   ],
-  "repositoryUrl": "https://github.com/akiojin/llm-router",
+  "repositoryUrl": "https://github.com/akiojin/llmlb",
   "tagFormat": "v${version}",
   "npmPublish": false,
   "tarballDir": false,

--- a/specs/SPEC-1f2a9c3d/contracts/openapi.yaml
+++ b/specs/SPEC-1f2a9c3d/contracts/openapi.yaml
@@ -118,7 +118,7 @@ components:
         target:
           type: string
           description: ログ出力元モジュール
-          example: xllm::api::router_client
+          example: xllm::api::openai_endpoints
         message:
           type: string
           description: ログメッセージ

--- a/specs/SPEC-1f2a9c3d/data-model.md
+++ b/specs/SPEC-1f2a9c3d/data-model.md
@@ -124,7 +124,7 @@ pub enum ProxyError {
     {
       "timestamp": "2025-01-02T10:30:00.123Z",
       "level": "INFO",
-      "target": "xllm::api::router_client",
+      "target": "xllm::api::openai_endpoints",
       "message": "Heartbeat sent",
       "runtime_id": "550e8400-e29b-41d4-a716-446655440000"
     },

--- a/specs/SPEC-1f2a9c3d/quickstart.md
+++ b/specs/SPEC-1f2a9c3d/quickstart.md
@@ -32,7 +32,7 @@ curl "http://localhost:11435/v0/logs?tail=50" | jq '.entries | length'
     {
       "timestamp": "2025-01-02T10:30:01.456Z",
       "level": "INFO",
-      "target": "xllm::api::router_client",
+      "target": "xllm::api::openai_endpoints",
       "message": "Registered with router"
     }
   ],


### PR DESCRIPTION
## Summary

- `.releaserc.json`: repositoryUrlを`llm-router`から`llmlb`に更新
- `specs/SPEC-1f2a9c3d/`: 削除済みの`router_client`参照を`openai_endpoints`に更新

## Test plan

- [x] CI Lint通過
- [x] CI Test通過
- [x] `llm-router`参照の残存なし確認済み
- [x] `LLM_ROUTER`参照の残存なし確認済み
- [x] `ALLM_`参照の残存なし確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)