### PR TITLE
fix(ci): handle prerelease versions in MSI build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
       RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
       RELEASE_VERSION: ${{ (github.event.inputs.release_tag != '' && github.event.inputs.release_tag) || github.ref_name }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -208,13 +209,17 @@ jobs:
             Write-Error "Release version is not available."
             exit 1
           }
+          # MSI only supports x.x.x.x format - strip prerelease suffix
+          # e.g., "3.0.0-alpha.4" -> "3.0.0.0"
+          $msiVersion = $version -replace '-.*$', '.0'
+          Write-Host "Original version: $version, MSI version: $msiVersion"
           $binaryDir = Join-Path $PWD "target/${{ matrix.target }}/release"
           $lbWxs = Join-Path $PWD "installers/windows/llmlb.wxs"
           $lbObj = "llmlb.wixobj"
           $lbMsi = "llmlb-${{ matrix.artifact }}.msi"
           $wixPath = "${env:ProgramFiles(x86)}\WiX Toolset v3.11\bin"
           $env:PATH = "$wixPath;$env:PATH"
-          candle.exe $lbWxs -out $lbObj -dBinariesDir="$binaryDir" -dProductVersion="$version"
+          candle.exe $lbWxs -out $lbObj -dBinariesDir="$binaryDir" -dProductVersion="$msiVersion"
           light.exe $lbObj -out $lbMsi -sice:ICE03
           "lb_msi=$lbMsi" >> $env:GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
- Add `fail-fast: false` to continue other builds when one fails
- Convert prerelease versions for MSI compatibility

## Test plan
- [x] Commit and push to develop
- [ ] Merge to main
- [ ] Re-run publish workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ビルドパイプラインの堅牢性を向上させ、単一プラットフォームのビルド失敗時に他のプラットフォームのビルドが継続されるようになりました
  * Windows MSIパッケージングのバージョン処理を改善し、プレリリース情報を除いた形式に対応しました
  * バージョン情報のログ出力を強化しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->