### PR TITLE
fix(ci): DependabotのPRターゲットをdevelopに修正

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,29 @@ updates:
     labels:
       - "dependencies"
       - "submodule"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    labels:
+      - "dependencies"
+      - "npm"
+    groups:
+      npm_and_yarn:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    labels:
+      - "dependencies"
+      - "cargo"
+    groups:
+      cargo:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,10 +1,9 @@
-name: Auto Merge PR
+name: Auto Merge Dependabot PR
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
-      - main
       - develop
 
 permissions:
@@ -13,9 +12,11 @@ permissions:
 
 jobs:
   auto-merge:
-    name: Enable auto-merge
+    name: Enable auto-merge for Dependabot
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: |
+      github.event.pull_request.draft == false &&
+      github.actor == 'dependabot[bot]'
     steps:
       - name: Enable auto-merge
         env:


### PR DESCRIPTION
## Summary

- dependabot.ymlにnpm/cargoエコシステムを追加（target-branch: develop）
- auto-merge.ymlをDependabot PRのみに限定
- mainブランチへの直接PRを防止

## 背景

PR #343のようにDependabotのセキュリティアラートPRがmainブランチをターゲットにしていた問題を修正。

## 変更内容

### dependabot.yml
- `npm`エコシステムを追加（グループ: npm_and_yarn）
- `cargo`エコシステムを追加
- すべてのエコシステムで`target-branch: develop`を設定

### auto-merge.yml
- ターゲットブランチを`develop`のみに変更（`main`を削除）
- `github.actor == 'dependabot[bot]'`条件を追加し、Dependabot PRのみ自動マージ対象に

## Test plan

- [ ] 既存のDependabot PR #343を手動でクローズ
- [ ] 新しいDependabot PRがdevelopをターゲットにすることを確認
- [ ] 通常のPRでは自動マージが有効にならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)