### PR TITLE
chore: xllm/third_partyをmarkdownlint除外対象に追加

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -16,6 +16,8 @@
     "**/vendor/**",
     "tmp/**",
     "**/tmp/**",
+    "xllm/third_party/**",
+    "**/third_party/**",
     "PLANS.md"
   ]
 }

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -11,3 +11,5 @@ tmp/
 **/tmp/**
 actions-runner/
 .worktrees/
+xllm/third_party/
+**/third_party/**


### PR DESCRIPTION
## Summary

- `xllm/third_party/` をmarkdownlint除外対象に追加
- サードパーティコードのlintエラーを回避

## Test plan

- [ ] markdownlintがエラーなしで完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)