### PR TITLE
Persist dashboard request totals in top cards

### DIFF
--- a/llmlb/src/api/responses.rs
+++ b/llmlb/src/api/responses.rs
@@ -23,7 +23,7 @@ use crate::{
         error::AppError,
         models::load_registered_model,
         proxy::{
-            forward_streaming_response, forward_to_endpoint,
+            forward_streaming_response, forward_to_endpoint, record_endpoint_request_stats,
             select_available_endpoint_with_queue_for_model, QueueSelection,
         },
     },
@@ -235,6 +235,12 @@ pub async fn post_responses(
                     .finish_request(endpoint.id, RequestOutcome::Error, duration)
                     .await
                     .map_err(AppError::from)?;
+                record_endpoint_request_stats(
+                    state.db_pool.clone(),
+                    endpoint.id,
+                    model.clone(),
+                    false,
+                );
                 return Err(AppError::from(e));
             }
         };
@@ -249,11 +255,14 @@ pub async fn post_responses(
         } else {
             RequestOutcome::Error
         };
+        let succeeded = response_status.is_success();
         state
             .load_manager
             .finish_request(endpoint.id, outcome, duration)
             .await
             .map_err(AppError::from)?;
+
+        record_endpoint_request_stats(state.db_pool.clone(), endpoint.id, model.clone(), succeeded);
 
         // SPEC-f8e3a1b7: 成功時に推論レイテンシを更新
         if response_status.is_success() {
@@ -279,6 +288,7 @@ pub async fn post_responses(
                 .finish_request(endpoint.id, RequestOutcome::Error, duration)
                 .await
                 .map_err(AppError::from)?;
+            record_endpoint_request_stats(state.db_pool.clone(), endpoint.id, model.clone(), false);
             return Err(AppError::from(LbError::Http(e.to_string())));
         }
     };
@@ -288,11 +298,13 @@ pub async fn post_responses(
     } else {
         RequestOutcome::Error
     };
+    let succeeded = status.is_success();
     state
         .load_manager
         .finish_request(endpoint.id, outcome, duration)
         .await
         .map_err(AppError::from)?;
+    record_endpoint_request_stats(state.db_pool.clone(), endpoint.id, model.clone(), succeeded);
 
     // SPEC-f8e3a1b7: 成功時に推論レイテンシを更新
     if status.is_success() {

--- a/llmlb/src/web/dashboard/src/components/dashboard/StatsCards.tsx
+++ b/llmlb/src/web/dashboard/src/components/dashboard/StatsCards.tsx
@@ -1,5 +1,5 @@
 import { type DashboardEndpoint, type DashboardStats } from '@/lib/api'
-import { formatNumber, formatDuration, formatPercentage } from '@/lib/utils'
+import { formatDuration, formatFullNumber, formatPercentage } from '@/lib/utils'
 import { Card, CardContent } from '@/components/ui/card'
 import {
   Server,
@@ -130,7 +130,7 @@ export function StatsCards({ stats, endpoints, isLoading }: StatsCardsProps) {
   const cards = [
     {
       title: 'Total Endpoints',
-      value: totalEndpoints != null ? formatNumber(totalEndpoints) : '—',
+      value: totalEndpoints != null ? formatFullNumber(totalEndpoints) : '—',
       subtitle: endpointsSubtitle,
       icon: <Server className="h-5 w-5 text-primary" />,
       accentColor: 'primary',
@@ -138,9 +138,9 @@ export function StatsCards({ stats, endpoints, isLoading }: StatsCardsProps) {
     },
     {
       title: 'Total Requests',
-      value: stats ? formatNumber(stats.total_requests) : '—',
+      value: stats ? formatFullNumber(stats.total_requests) : '—',
       subtitle: stats
-        ? `${formatNumber(stats.successful_requests)} successful`
+        ? `${formatFullNumber(stats.successful_requests)} successful`
         : undefined,
       icon: <Activity className="h-5 w-5 text-chart-2" />,
       accentColor: 'chart-2',
@@ -148,9 +148,11 @@ export function StatsCards({ stats, endpoints, isLoading }: StatsCardsProps) {
     },
     {
       title: 'Total Tokens',
-      value: stats ? formatNumber(stats.total_tokens) : '—',
+      value: stats ? formatFullNumber(stats.total_tokens) : '—',
       subtitle: stats
-        ? `In: ${formatNumber(stats.total_input_tokens)} / Out: ${formatNumber(stats.total_output_tokens)}`
+        ? `In: ${formatFullNumber(stats.total_input_tokens)} / Out: ${formatFullNumber(
+            stats.total_output_tokens
+          )}`
         : undefined,
       icon: <MessageSquare className="h-5 w-5 text-chart-5" />,
       accentColor: 'chart-5',
@@ -158,14 +160,14 @@ export function StatsCards({ stats, endpoints, isLoading }: StatsCardsProps) {
     },
     {
       title: 'Active Requests',
-      value: stats ? formatNumber(stats.total_active_requests) : '—',
+      value: stats ? formatFullNumber(stats.total_active_requests) : '—',
       icon: <Cpu className="h-5 w-5 text-chart-1" />,
       accentColor: 'chart-1',
       dataStat: 'active-requests',
     },
     {
       title: 'Queued Requests',
-      value: stats ? formatNumber(stats.queued_requests) : '—',
+      value: stats ? formatFullNumber(stats.queued_requests) : '—',
       icon: <Hourglass className="h-5 w-5 text-chart-5" />,
       accentColor: 'chart-5',
       dataStat: 'queued-requests',
@@ -179,7 +181,7 @@ export function StatsCards({ stats, endpoints, isLoading }: StatsCardsProps) {
             )
           : '—',
       subtitle: stats
-        ? `${formatNumber(stats.failed_requests)} failed`
+        ? `${formatFullNumber(stats.failed_requests)} failed`
         : undefined,
       icon:
         stats && stats.failed_requests > 0 ? (

--- a/llmlb/src/web/dashboard/src/lib/utils.ts
+++ b/llmlb/src/web/dashboard/src/lib/utils.ts
@@ -43,6 +43,11 @@ export function formatNumber(num: number | null | undefined): string {
   return num.toLocaleString()
 }
 
+export function formatFullNumber(num: number | null | undefined): string {
+  if (num == null) return '-'
+  return num.toLocaleString('ja-JP')
+}
+
 export function formatPercentage(value: number | null | undefined, decimals = 1): string {
   if (value == null) return '-'
   return `${value.toFixed(decimals)}%`


### PR DESCRIPTION
## Summary
- Use persisted endpoint counters for dashboard top-card totals (total/successful/failed requests).
- Keep active counters from LoadManager as fallback if persisted query fails.
- Add DB utility to aggregate endpoint request counters.
- Add E2E tests for /api/dashboard/stats and /api/dashboard/overview persisting request totals.
- Update top-card number display to non-abbreviating format for large values.

## Changes
- `llmlb/src/db/endpoints.rs`
  - Added `get_request_totals()` and `EndpointRequestTotals`.
  - Added unit test `test_get_request_totals`.
- `llmlb/src/api/dashboard.rs`
  - `collect_stats()` now loads request totals from persisted endpoint counters.
- `llmlb/tests/e2e/dashboard_flow_test.rs`
  - Added E2E tests covering persisted request totals in stats and overview.
- `llmlb/src/web/dashboard/src/lib/utils.ts`
  - Added `formatFullNumber()`.
- `llmlb/src/web/dashboard/src/components/dashboard/StatsCards.tsx`
  - Use full number formatting for top cards.
