### PR TITLE
ci(auto-merge): allow trusted author PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-name: Auto Merge Dependabot PR
+name: Auto Merge Allowed PRs
 
 on:
   pull_request_target:
@@ -12,11 +12,12 @@ permissions:
 
 jobs:
   auto-merge:
-    name: Enable auto-merge for Dependabot
+    name: Enable auto-merge for allowed authors
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.draft == false &&
-      github.actor == 'dependabot[bot]'
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJson('["akiojin","dependabot[bot]"]'), github.event.pull_request.user.login)
     steps:
       - name: Enable auto-merge
         env:


### PR DESCRIPTION
## Summary
- allow auto-merge to be enabled automatically for `akiojin` and `dependabot[bot]` PRs from branches in the same repository.
- keep auto-merge on the merge-commit path so the workflow never requests squash or rebase merges.
- align the workflow with the repository merge policy that now disables squash and rebase merges.

## Changes
- `.github/workflows/auto-merge.yml`: broaden the allowlist from Dependabot-only to trusted same-repo authors and keep `gh pr merge --auto --merge`.

## Testing
- `gh workflow view auto-merge.yml`
- `gh api repos/akiojin/llmlb --jq '{allow_auto_merge,allow_merge_commit,allow_rebase_merge,allow_squash_merge}'`
- `gh api repos/akiojin/llmlb/branches/develop/protection --jq '{required_linear_history,required_conversation_resolution}'`

## Closing Issues
None

## Related Issues / Links
None

## Checklist
- [x] Tests or verification steps were run.
- [x] No squash merge path is requested by this change.
- [x] Docs updated — N/A: workflow-only change.
- [x] Breaking change — N/A: no runtime or API behavior change.
