### PR TITLE
chore(release): v5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [5.4.1](https://github.com/akiojin/llmlb/compare/v5.4.0...v5.4.1) (2026-04-05)
+
+### Chore
+
+- Cargo 依存パッケージの更新（cargo group 6件、tar 0.4.44→0.4.45）
+- npm/yarn 依存パッケージの更新（12件）
+
 ## [5.4.0](https://github.com/akiojin/llmlb/compare/v5.2.5...v5.4.0) (2026-04-05)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,7 +2507,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llmlb"
-version = "5.4.0"
+version = "5.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["llmlb"]
 resolver = "2"
 
 [workspace.package]
-version = "5.4.0"
+version = "5.4.1"
 edition = "2021"
 authors = ["LLM Router Contributors"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- リリース v5.4.1
- Cargo / npm 依存パッケージの更新

## Release Notes

### Chore

- Cargo 依存パッケージの更新（cargo group 6件、tar 0.4.44→0.4.45）
- npm/yarn 依存パッケージの更新（12件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **チョア**
  * バージョン 5.4.1 をリリースしました
  * Rust（Cargo）パッケージおよび npm/yarn パッケージを含む複数の依存関係を最新版に更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->