### PR TITLE
docs(claude): add mandatory SPEC search preflight to workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,9 @@ llmlbは**APIゲートウェイ**として機能し、エンドポイントを**
 
 #### Step 1: 仕様策定（TDD RED の前に必須）
 
-`/gwt-issue-spec-ops` を使用してGitHub Issue上で仕様を定義する。
+1. `gwt-issue-search` で既存 SPEC を検索し、対象ドメインをカバーするものがあるか確認する
+2. 既存 SPEC に該当する → `/gwt-spec-ops` で既存 SPEC を更新する
+3. どのドメインにも当てはまらない → `/gwt-spec-register` で新規 SPEC を作成し `/gwt-spec-ops` で進める
 
 **仕様Issueが完成して初めて Step 2 に進める。**
 
@@ -495,12 +497,12 @@ scripts/checks/check-commits.sh --from origin/main --to HEAD
 
 新機能の開発は、GitHub Issue（`gwt-spec`ラベル）で仕様を管理します：
 
-1. **`/gwt-issue-spec-ops`**: GitHub Issue上で仕様を定義・管理
-   - ビジネス要件とユーザーストーリーを定義
+1. **`gwt-issue-search`（必須プリフライト）**: 既存 SPEC を検索し、対象ドメインをカバーするものがないか確認する
+2. **既存 SPEC あり** → `/gwt-spec-ops` で既存 SPEC を更新する
+   - ビジネス要件とユーザーストーリーを追記・修正
    - 「何を」「なぜ」に焦点を当てる（「どのように」は含めない）
-   - Issue番号で仕様を一意に識別
-
-2. 実装計画・タスク分解もIssue上で管理
+3. **既存 SPEC なし** → `/gwt-spec-register` で新規 SPEC を作成してから `/gwt-spec-ops` で進める
+4. 実装計画・タスク分解もIssue上で管理
 
 #### 環境固定ルール（プロジェクトカスタム）
 
@@ -556,13 +558,14 @@ scripts/checks/check-commits.sh --from origin/main --to HEAD
 
 **すべての機能開発・要件追加は GitHub Issue（`gwt-spec`ラベル）から開始**
 
-**新規機能開発フロー**:
+**機能開発フロー**:
 
-1. `/gwt-issue-spec-ops` - GitHub Issueでビジネス要件を定義（技術詳細なし）
-2. Issue上で技術設計・タスク分解を実施
-3. タスク実行（TDDサイクル厳守）
+1. `gwt-issue-search` — 既存 SPEC を検索（必須プリフライト）
+2. 既存 SPEC あり → `/gwt-spec-ops` で更新、なし → `/gwt-spec-register` で新規作成してから `/gwt-spec-ops` で進める
+3. Issue上で技術設計・タスク分解を実施
+4. タスク実行（TDDサイクル厳守）
    - 割り当て済みブランチ上で実装し、コミットを積む。ブランチ操作は禁止。
-4. 完了時はメンテナの指示に従う
+5. 完了時はメンテナの指示に従う
 
 **仕様作成原則**:
 


### PR DESCRIPTION
## Summary

- Updated CLAUDE.md to clarify that `gwt-issue-search` is a mandatory preflight step before any SPEC registration or modification, ensuring developers search for existing SPECs first before creating new ones.

## Changes

- `CLAUDE.md`: Added explicit steps to Step 1 (仕様策定) to search existing SPECs using `gwt-issue-search` before deciding whether to update an existing SPEC or create a new one.
- `CLAUDE.md`: Restructured "GitHub Issue-first 仕様管理" section to emphasize gwt-issue-search as mandatory preflight.
- `CLAUDE.md`: Reordered "Issue-first 開発規約" to place existing SPEC search as the first step in the workflow.

## Testing

- [x] `pnpm dlx markdownlint-cli2 "**/*.md" "!node_modules" "!.git" "!.github" "!.worktrees"` — 0 errors verified

## Closing Issues

- None

## Related Issues / Links

- Related to: #612 (root cause analysis and workflow improvements)

## Checklist

- [x] Tests added/updated — N/A: documentation-only change
- [x] Lint/format passed — markdownlint: 0 errors
- [x] Documentation updated — Yes, CLAUDE.md updated
- [ ] Migration/backfill plan included — N/A: no schema/data change
- [x] CHANGELOG impact considered — N/A: internal process change

## Context

The CLAUDE.md documentation previously described an incorrect workflow where SPEC creation happened before checking for existing SPECs that might already cover the requested domain. The correct flow is:

1. Search existing SPECs first using `gwt-issue-search` (mandatory preflight)
2. If a SPEC exists for the domain → update it with `/gwt-spec-ops`
3. If no SPEC exists → create a new one with `/gwt-spec-register`, then proceed with `/gwt-spec-ops`

This change aligns the documentation with the intended gwt ecosystem workflow.
