### PR TITLE
chore(release): v5.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [5.7.0](https://github.com/akiojin/llmlb/compare/v5.6.0...v5.7.0) (2026-04-14)
+
+### Added
+
+- Anthropic Messages API (`/v1/messages`) ツール呼び出し機能の実装
+
+### Fixed
+
+- Models: resolve_engine_names 関数でのバックワード互換性保持
+- Anthropic: streaming テスト内の always-true assertion削除
+- Models: Qwen canonical names を HuggingFace 標準に統一
+- Migrations: FTS5 設定エラーの修正
+
+### Refactor
+
+- Anthropic: Tool conversion logic を小さな関数へ分割（可読性向上）
+
 ## [5.6.0](https://github.com/akiojin/llmlb/compare/v5.5.0...v5.6.0) (2026-04-10)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,7 +2492,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llmlb"
-version = "5.6.0"
+version = "5.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["llmlb"]
 resolver = "2"
 
 [workspace.package]
-version = "5.6.0"
+version = "5.7.0"
 edition = "2021"
 authors = ["LLM Router Contributors"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

リリース v5.7.0

## Release Notes

### Added
- Anthropic API `/v1/messages` エンドポイントにツール呼び出しサポートを追加
- Tool conversion logic の構造化と可読性向上

### Fixed
- 各種バグ修正

## Closing Issues

(該当する issue がある場合は記載)