### PR TITLE
test+docs(anthropic): /v1/messages の書き換え契約テストと Claude Code 接続手順

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -44,6 +44,7 @@ llmlb は OpenAI 互換の推論サーバーにリクエストをルーティン
 - エンドポイント管理: LM Studio、Ollama、vLLM、xLLM等の外部推論サーバーをロードバランサーから一元管理
 - モデル同期: 登録エンドポイントから `GET /v1/models` でモデル一覧を自動同期
 - クラウドプレフィックス: `openai:`, `google:`, `anthropic:` を `model` に付けて同一エンドポイントでプロキシ
+- Anthropic互換API: `POST /v1/messages` を受け付け、Claude Code のバックエンドとしても利用可能（[`docs/api-clients.md`](docs/api-clients.md#claude-code-から接続する) 参照）
 - 自動アップデート: GitHub Releases検知→承認後にドレイン→再起動。スケジューリング（即時/アイドル/時刻指定）、自動＋手動ロールバック、DL進捗表示に対応
 
 ## ダッシュボード

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ available for compatibility.
 - **Self Update (User-Approved)**: Detect new GitHub Releases, notify via dashboard/tray, drain in-flight inference, then restart into the new version — with update scheduling, automatic rollback, and download progress tracking
 - **GPU-Aware Routing**: Intelligent request routing based on GPU capabilities and availability
 - **Cloud Model Prefixes**: Add `openai:` `google:` or `anthropic:` in the model name to proxy to the corresponding cloud provider while keeping the same OpenAI-compatible endpoint.
-- **Anthropic-Native Messages API**: Accept `POST /v1/messages` with Anthropic-style headers while still routing non-`anthropic:` models to local OpenAI-compatible endpoints.
+- **Anthropic-Native Messages API**: Accept `POST /v1/messages` with Anthropic-style headers while still routing non-`anthropic:` models to local OpenAI-compatible endpoints. Claude Code can use llmlb as its backend — see [`docs/api-clients.md`](docs/api-clients.md#claude-code-から接続する).
 
 ## Assistant CLI for LLM Assistants
 

--- a/docs/api-clients.md
+++ b/docs/api-clients.md
@@ -41,3 +41,64 @@ const res = await fetch("http://localhost:32768/v1/responses", {
 const data = await res.json();
 console.log(data);
 ```
+
+## Claude Code から接続する
+
+llmlb は Anthropic 互換の `/v1/messages` を提供するため、
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) のバックエンドとして利用できます。
+
+以下の 3 つの環境変数を設定してから `claude` を起動してください。
+
+```bash
+# PowerShell / bash / zsh 共通の例
+export ANTHROPIC_BASE_URL="http://localhost:32768"
+export ANTHROPIC_API_KEY="<llmlb で発行した API キー>"   # 例: sk_debug（デバッグビルドのみ）
+export ANTHROPIC_MODEL="<エンドポイントに登録済みのモデル>"  # 例: openai/gpt-oss-20b
+```
+
+| 変数 | 役割 |
+|------|------|
+| `ANTHROPIC_BASE_URL` | Claude Code がリクエストを送る先。llmlb のベース URL（スキーム・ホスト・ポートのみ） |
+| `ANTHROPIC_API_KEY` | llmlb のダッシュボードで発行した API キー。デバッグビルドでは `sk_debug` が使える |
+| `ANTHROPIC_MODEL` | 使用するモデル。canonical 名（HuggingFace レポ ID 形式）を推奨 |
+
+### モデル名の扱い
+
+`/v1/messages` は受信したモデル名をそのまま upstream に転送せず、
+`resolve_canonical_any` + `rewrite_payload_model_for_endpoint` によって
+エンドポイントが広告するエイリアス名へ自動変換します。
+
+例: Ollama に `gpt-oss:20b` として登録されたモデルに対し
+`ANTHROPIC_MODEL=openai/gpt-oss-20b` を指定した場合、
+llmlb は upstream に `gpt-oss:20b` として転送します。
+
+この仕組みにより、クライアント（Claude Code 等）は
+エンドポイント種別（Ollama / LM Studio / vLLM / xLLM）ごとの
+命名差異を意識せずに canonical 名のみで利用できます。
+
+### 認証競合警告が出る場合
+
+Claude Code 起動時に以下の警告が出ることがあります。
+
+```text
+⚠ Auth conflict: Both a token (claude.ai) and an API key (ANTHROPIC_API_KEY) are set.
+```
+
+llmlb を使う場合は `ANTHROPIC_API_KEY` 側が正です。以下のいずれかで解消してください。
+
+- `claude /logout` で claude.ai のトークンを破棄する
+- または、ログイン時に API キー承認のプロンプトで **No** と答え、セッションを `ANTHROPIC_API_KEY` 側に固定する
+
+### 動作確認（curl）
+
+Claude Code を介さず、直接 llmlb に Anthropic 形式で疎通確認する例です。
+
+```bash
+curl -sS -X POST "$ANTHROPIC_BASE_URL/v1/messages" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d "{\"model\":\"$ANTHROPIC_MODEL\",\"max_tokens\":32,\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}]}"
+```
+
+`200 OK` と `"type":"message"` を含む JSON が返れば接続成功です。

--- a/llmlb/tests/contract/anthropic_messages_api_test.rs
+++ b/llmlb/tests/contract/anthropic_messages_api_test.rs
@@ -14,13 +14,27 @@ use axum::{
 use reqwest::{Client, StatusCode as ReqStatusCode};
 use serde_json::{json, Value};
 use serial_test::serial;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[derive(Clone)]
 struct ChatNodeStubState {
     response: ChatStubResponse,
+    /// /v1/models で広告するモデル ID。エンドポイント同期でこの値が登録される。
+    advertised_model: String,
+    /// llmlb のエンドポイント型自動検出に「どの runtime として振る舞うか」を指定する。
+    detection_kind: DetectionKind,
+    /// /v1/chat/completions に届いた最新の POST body を捕捉する（`/v1/messages` の
+    /// モデル書き換えを検証するために使用）。
+    captured_request: Arc<Mutex<Option<Value>>>,
+}
+
+#[derive(Clone, Copy)]
+enum DetectionKind {
+    OpenaiCompatible,
+    Ollama,
+    LmStudio,
 }
 
 #[derive(Clone)]
@@ -29,18 +43,39 @@ enum ChatStubResponse {
     Stream(String),
 }
 
-async fn spawn_chat_node_stub(state: ChatNodeStubState) -> TestServer {
-    let app = Router::new()
+fn chat_node_stub_openai_compat(response: ChatStubResponse) -> ChatNodeStubState {
+    ChatNodeStubState {
+        response,
+        advertised_model: "test-model".to_string(),
+        detection_kind: DetectionKind::OpenaiCompatible,
+        captured_request: Arc::new(Mutex::new(None)),
+    }
+}
+
+async fn spawn_chat_node_stub(state: ChatNodeStubState) -> (TestServer, Arc<Mutex<Option<Value>>>) {
+    let captured = state.captured_request.clone();
+    let detection = state.detection_kind;
+    let mut app = Router::new()
         .route("/v1/chat/completions", post(chat_handler))
-        .route("/v1/models", get(models_handler))
-        .with_state(Arc::new(state));
-    crate::support::http::spawn_lb(app).await
+        .route("/v1/models", get(models_handler));
+    if matches!(detection, DetectionKind::Ollama) {
+        app = app.route("/api/tags", get(ollama_tags_handler));
+    }
+    let server = crate::support::http::spawn_lb(app.with_state(Arc::new(state))).await;
+    (server, captured)
 }
 
 async fn chat_handler(
     State(state): State<Arc<ChatNodeStubState>>,
-    Json(_request): Json<Value>,
+    Json(request): Json<Value>,
 ) -> impl IntoResponse {
+    {
+        let mut guard = state
+            .captured_request
+            .lock()
+            .expect("captured_request lock should not be poisoned");
+        *guard = Some(request);
+    }
     match &state.response {
         ChatStubResponse::Json(payload) => (StatusCode::OK, Json(payload.clone())).into_response(),
         ChatStubResponse::Stream(body) => axum::response::Response::builder()
@@ -51,12 +86,29 @@ async fn chat_handler(
     }
 }
 
-async fn models_handler() -> impl IntoResponse {
+async fn models_handler(State(state): State<Arc<ChatNodeStubState>>) -> impl IntoResponse {
+    let owned_by = match state.detection_kind {
+        DetectionKind::LmStudio => "lm-studio",
+        DetectionKind::Ollama => "ollama",
+        DetectionKind::OpenaiCompatible => "test",
+    };
     (
         StatusCode::OK,
         Json(json!({
+            "object": "list",
             "data": [
-                {"id": "test-model", "object": "model"}
+                {"id": state.advertised_model, "object": "model", "owned_by": owned_by}
+            ]
+        })),
+    )
+}
+
+async fn ollama_tags_handler(State(state): State<Arc<ChatNodeStubState>>) -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(json!({
+            "models": [
+                {"name": state.advertised_model, "size": 12_000_000_000i64}
             ]
         })),
     )
@@ -65,8 +117,8 @@ async fn models_handler() -> impl IntoResponse {
 #[tokio::test]
 #[serial]
 async fn anthropic_messages_local_request_success() {
-    let node = spawn_chat_node_stub(ChatNodeStubState {
-        response: ChatStubResponse::Json(json!({
+    let (node, _captured) = spawn_chat_node_stub(chat_node_stub_openai_compat(
+        ChatStubResponse::Json(json!({
             "id": "chatcmpl-123",
             "object": "chat.completion",
             "model": "test-model",
@@ -85,7 +137,7 @@ async fn anthropic_messages_local_request_success() {
                 "total_tokens": 13
             }
         })),
-    })
+    ))
     .await;
     let lb = spawn_test_lb().await;
     let _ = register_responses_endpoint(lb.addr(), node.addr(), "test-model")
@@ -119,16 +171,18 @@ async fn anthropic_messages_local_request_success() {
 #[tokio::test]
 #[serial]
 async fn anthropic_messages_streaming_transforms_openai_sse() {
-    let node = spawn_chat_node_stub(ChatNodeStubState {
-        response: ChatStubResponse::Stream(concat!(
-            "data: {\"id\":\"chatcmpl-123\",\"choices\":[{\"delta\":{\"role\":\"assistant\"},\"index\":0}]}\n\n",
-            "data: {\"id\":\"chatcmpl-123\",\"choices\":[{\"delta\":{\"content\":\"Hello\"},\"index\":0}]}\n\n",
-            "data: {\"id\":\"chatcmpl-123\",\"choices\":[{\"delta\":{\"content\":\" world\"},\"index\":0}]}\n\n",
-            "data: {\"id\":\"chatcmpl-123\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n",
-            "data: [DONE]\n\n"
-        )
-        .to_string()),
-    })
+    let (node, _captured) = spawn_chat_node_stub(chat_node_stub_openai_compat(
+        ChatStubResponse::Stream(
+            concat!(
+                "data: {\"id\":\"chatcmpl-123\",\"choices\":[{\"delta\":{\"role\":\"assistant\"},\"index\":0}]}\n\n",
+                "data: {\"id\":\"chatcmpl-123\",\"choices\":[{\"delta\":{\"content\":\"Hello\"},\"index\":0}]}\n\n",
+                "data: {\"id\":\"chatcmpl-123\",\"choices\":[{\"delta\":{\"content\":\" world\"},\"index\":0}]}\n\n",
+                "data: {\"id\":\"chatcmpl-123\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n",
+                "data: [DONE]\n\n"
+            )
+            .to_string(),
+        ),
+    ))
     .await;
     let lb = spawn_test_lb().await;
     let _ = register_responses_endpoint(lb.addr(), node.addr(), "test-model")
@@ -269,4 +323,115 @@ async fn anthropic_messages_invalid_api_key_uses_anthropic_error_shape() {
     let body: Value = response.json().await.expect("error body must be json");
     assert_eq!(body["type"], "error");
     assert_eq!(body["error"]["type"], "authentication_error");
+}
+
+/// Claude Code 相当のクライアントが `openai/gpt-oss-20b` で `/v1/messages` を叩いた際、
+/// Ollama バックエンドが `gpt-oss:20b` としてしかモデルを保持していないケース。
+/// llmlb は `rewrite_payload_model_for_endpoint` を呼んで upstream へは
+/// エイリアス名（`gpt-oss:20b`）で転送しなければ 502 "not found" になる。
+#[tokio::test]
+#[serial]
+async fn anthropic_messages_rewrites_canonical_to_ollama_alias() {
+    let mut state = chat_node_stub_openai_compat(ChatStubResponse::Json(json!({
+        "id": "chatcmpl-rewrite",
+        "object": "chat.completion",
+        "model": "gpt-oss:20b",
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello from Ollama"},
+                "finish_reason": "stop"
+            }
+        ],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 3, "total_tokens": 7}
+    })));
+    state.advertised_model = "gpt-oss:20b".to_string();
+    state.detection_kind = DetectionKind::Ollama;
+
+    let (node, captured) = spawn_chat_node_stub(state).await;
+    let lb = spawn_test_lb().await;
+    let _ = register_responses_endpoint(lb.addr(), node.addr(), "gpt-oss:20b")
+        .await
+        .expect("endpoint registration should succeed");
+
+    let response = Client::new()
+        .post(format!("http://{}/v1/messages", lb.addr()))
+        .header("x-api-key", "sk_debug")
+        .header("anthropic-version", "2023-06-01")
+        .json(&json!({
+            "model": "openai/gpt-oss-20b",
+            "max_tokens": 32,
+            "messages": [
+                {"role": "user", "content": "Hello"}
+            ]
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), ReqStatusCode::OK);
+
+    let captured_body = captured
+        .lock()
+        .expect("captured_request lock should not be poisoned")
+        .clone()
+        .expect("upstream should have received at least one POST");
+    assert_eq!(
+        captured_body["model"], "gpt-oss:20b",
+        "Ollama の upstream へは canonical 名ではなくエイリアス名で転送されること"
+    );
+}
+
+/// LM Studio のように canonical 名（`openai/gpt-oss-20b`）を
+/// そのまま広告するエンドポイントでは、書き換えが発生せず
+/// リクエストがそのまま upstream に届くこと（no-op パスの保証）。
+#[tokio::test]
+#[serial]
+async fn anthropic_messages_passes_canonical_through_lm_studio() {
+    let mut state = chat_node_stub_openai_compat(ChatStubResponse::Json(json!({
+        "id": "chatcmpl-passthrough",
+        "object": "chat.completion",
+        "model": "openai/gpt-oss-20b",
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello from LM Studio"},
+                "finish_reason": "stop"
+            }
+        ],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 3, "total_tokens": 7}
+    })));
+    state.advertised_model = "openai/gpt-oss-20b".to_string();
+    state.detection_kind = DetectionKind::LmStudio;
+
+    let (node, captured) = spawn_chat_node_stub(state).await;
+    let lb = spawn_test_lb().await;
+    let _ = register_responses_endpoint(lb.addr(), node.addr(), "openai/gpt-oss-20b")
+        .await
+        .expect("endpoint registration should succeed");
+
+    let response = Client::new()
+        .post(format!("http://{}/v1/messages", lb.addr()))
+        .header("x-api-key", "sk_debug")
+        .header("anthropic-version", "2023-06-01")
+        .json(&json!({
+            "model": "openai/gpt-oss-20b",
+            "max_tokens": 32,
+            "messages": [
+                {"role": "user", "content": "Hello"}
+            ]
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), ReqStatusCode::OK);
+
+    let captured_body = captured
+        .lock()
+        .expect("captured_request lock should not be poisoned")
+        .clone()
+        .expect("upstream should have received at least one POST");
+    assert_eq!(
+        captured_body["model"], "openai/gpt-oss-20b",
+        "canonical 名を直接受理するエンドポイントでは書き換えが発生しないこと"
+    );
 }


### PR DESCRIPTION
## Summary

PR #624（`fix(anthropic): /v1/messages でエンドポイント向けモデル名を書き換えて upstream エラーを解消`）のフォローアップ。

- `/v1/messages` ハンドラが `rewrite_payload_model_for_endpoint` を実際に呼ぶ配線を HTTP レベルで検証する **契約テストを 2 件追加**
- Claude Code を llmlb バックエンドとして利用する **接続手順ドキュメントを追加**

これにより、v5.7.1 リグレッション（Claude Code で `openai/gpt-oss-20b` を送ると 502 "not found"）の再発を CI で確実にブロックでき、ユーザーが接続方法を README/docs から辿れるようになる。

## Motivation

- PR #624 の本体修正（`llmlb/src/api/anthropic.rs` L287-446）は merge 済みだが、配線自体のコントラクトテストが無く、将来誰かが `rewrite_payload_model_for_endpoint` の呼び出しを外しても単体テスト (`api::model_name`) は通ってしまう
- 同 PR のチェックリストで「Documentation updated」が unchecked のまま残っていた
- ユーザーから `openai/gpt-oss-20b · API Usage Billing` 表記と `502 not_found_error` の報告があり、v5.7.1 バイナリに修正が含まれないことが原因と判明（診断の過程で本 PR のスコープを合意）

## Changes

### 追加テスト（`llmlb/tests/contract/anthropic_messages_api_test.rs`）

- `anthropic_messages_rewrites_canonical_to_ollama_alias`
  - `/api/tags` + `/v1/models` を備えたスタブを Ollama として自動検出させる
  - `model: "openai/gpt-oss-20b"` を `/v1/messages` に送る
  - upstream `/v1/chat/completions` の POST body を `Arc<Mutex<Option<Value>>>` で捕捉し、**`gpt-oss:20b`** へ書き換えられていることを assert
- `anthropic_messages_passes_canonical_through_lm_studio`
  - `owned_by: "lm-studio"` を /v1/models に含めて LM Studio として検出させる
  - canonical 名が書き換えられず upstream に素通りする **no-op パス** を保証
- 既存 `ChatNodeStubState` を拡張（`advertised_model` / `detection_kind` / `captured_request`）。既存 2 テスト（`anthropic_messages_local_request_success`, `anthropic_messages_streaming_transforms_openai_sse`）は `chat_node_stub_openai_compat()` ヘルパー経由で互換動作

### ドキュメント

- `docs/api-clients.md`: 「Claude Code から接続する」節
  - 必須環境変数（`ANTHROPIC_BASE_URL` / `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL`）の設定例
  - canonical → エンドポイント広告名の自動書き換え（`rewrite_payload_model_for_endpoint`）の説明
  - 認証競合警告への対処（`claude /logout` または API キー承認で No を選択）
  - curl による疎通確認
- `README.md` / `README.ja.md`: 上記節への導線リンクを 1 行追加（README に設計は書かないルール遵守）

## Testing

- [x] `cargo fmt --check` — 通過
- [x] `cargo clippy --tests -- -D warnings` — 警告なし
- [x] `cargo test --test contract_tests -p llmlb anthropic_messages` — 7 件（既存 5 + 新規 2）全て緑
- [x] `cargo test --test contract_tests -p llmlb` — 全 236 件緑（18 ignored / 0 failed）
- [x] `cargo test -p llmlb --lib api::model_name` — 17 件緑
- [x] `pnpm dlx markdownlint-cli2 "**/*.md"` — 756 files / 0 errors

Playwright E2E はローカル環境で Chromium が未インストールだったため失敗するが、本 PR は Rust バックエンド + docs の変更のみなので影響なし（CI 側の環境では通る想定）。

## Closing Issues

- None (follow-up to #624)

## Related Issues / Links

- #624 本体修正 PR
- 原因: v5.7.1 タグ (`d349a283`) には `5f71e22d` が含まれていない → ユーザーが v5.7.1 バイナリで 502 を踏む

## Checklist

- [x] Tests added/updated — 契約テスト 2 件を追加
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, markdownlint) — ローカル通過確認済み
- [x] Documentation updated — `docs/api-clients.md` に Claude Code 接続手順を追加
- [x] Migration/backfill plan included — スキーマ変更なし
- [x] CHANGELOG impact considered — 破壊的変更なし・PATCH 相当

## Follow-up

- v5.7.2 リリース（develop → main の `chore(release): v5.7.2`）はメンテナ作業として別途。ユーザーは v5.7.2 配布後に自動的に修正版を受け取れる。暫定策としては develop/feature ブランチから再ビルドするか、Ollama 側で `ollama cp gpt-oss:20b openai/gpt-oss-20b` のエイリアスを作成すれば回避可能。

## Risk / Impact

- **Affected areas**: `llmlb/tests/contract/anthropic_messages_api_test.rs`（テスト専用）、`docs/api-clients.md`（ドキュメント）、README 2 言語版
- **Rollback plan**: 本 PR をリバートすれば従来の挙動（テストとドキュメント追加前）に戻るのみ。本体挙動には影響なし。