### PR TITLE
docs(lessons): Claude Code 502 調査の教訓と pre-push を通すための依存更新

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,5 +9,6 @@
 [advisories]
 ignore = [
   "RUSTSEC-2023-0071", # rsa: no fixed upgrade; unreachable unless sqlx-mysql feature is enabled
+  "RUSTSEC-2026-0097", # rand 0.10.0 unsound with custom logger; temporary ignore — permanent fix tracked in #630
 ]
 

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,6 +9,5 @@
 [advisories]
 ignore = [
   "RUSTSEC-2023-0071", # rsa: no fixed upgrade; unreachable unless sqlx-mysql feature is enabled
-  "RUSTSEC-2026-0097", # rand 0.10.0 unsound with custom logger; temporary ignore — permanent fix tracked in #630
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,7 +2517,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "qrcode",
- "rand 0.10.0",
+ "rand 0.10.1",
  "regex",
  "reqwest",
  "rpassword",
@@ -3704,9 +3704,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -4843,7 +4843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4080,9 +4080,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/memory/lessons.md
+++ b/memory/lessons.md
@@ -17,3 +17,17 @@
 - **原因**: tokio の `RwLock` はリエントラントではないため、同一タスクが write lock を保持したまま read lock を取得しようとすると永久にブロックされる。Rust の NLL はボローチェッカーの分析にのみ影響し、Drop のタイミング（スコープ末尾）は変えない
 - **再発防止ルール**: `RwLockWriteGuard` / `RwLockReadGuard` は必ずスコープブロック `{ }` で囲み、`.await` をまたがせない。名前付きガード変数がある場合は `.await` の前に `drop()` するかブロックで囲む
 - **次回チェック方法**: `state.write().await` を名前付き変数に束縛している箇所で、同一スコープ内に `.await` がないか grep で確認
+
+### エンドポイントのヘルスチェック Online は推論成功を意味しない
+
+- **事象**: Claude Code から `/v1/messages` に `openai/gpt-oss-20b` で問い合わせたところ、ダッシュボード上は Online 表示の LM Studio エンドポイントで 2 分ちょうど（= 120 s）で `502 OpenAI-compatible upstream request failed` が連発。成功率は 2.5% まで下がっていた
+- **原因**: `/v1/models` への軽量ヘルスチェックは即応するが、20B モデルの初回 `/v1/chat/completions` は VRAM ロードだけで既定 `inference_timeout_secs=120` を超える。reqwest の `send()` がタイムアウトし `forward_to_endpoint` が Err を返す
+- **再発防止ルール**: 502 系の症状を見たら、まずダッシュボードの Endpoints 成功率と Avg Response Time、該当 History の Duration / Error を確認する。ヘルスチェック通過だけでは推論可否を保証しないので、`inference_timeout_secs` をモデル規模に合わせて個別に設定する（目安: 20B 級は 600 s 以上、クラウドプロキシは 120 s でよい）
+- **次回チェック方法**: Dashboard → Endpoints の該当行の成功率カラム、History → 該当レコードの Duration が `inference_timeout_secs` と一致していないかを確認する
+
+### Anthropic 502 レスポンスの message はハードコードで、実エラーは握りつぶされる
+
+- **事象**: クライアントには `OpenAI-compatible upstream request failed` としか返らず、タイムアウトなのか接続拒否なのか DNS なのか区別できない。原因特定が大幅に遅れた
+- **原因**: `llmlb/src/api/anthropic.rs:500-504` で `forward_to_endpoint` の `Err` を固定文字列に差し替えている。`proxy.rs:394-401` の `tracing::error!` には reqwest の実エラーが出ているが、HTTP 応答には反映されない。`/v1/chat/completions` 側の同種パスも同じ構造
+- **再発防止ルール**: 502 受領時はクライアント出力だけで判断せず、`Dashboard → History → Request Details → Error` フィールド、もしくは llmlb の標準エラー出力（tracing）を必ず確認する。中期的にはエラーメッセージの透過化（`LbError` の実メッセージを Anthropic 応答に流す）を別 SPEC で対応する
+- **次回チェック方法**: `GET /api/request_history` または Dashboard の該当レコードの Error フィールド、llmlb プロセスの標準出力で `Failed to forward request to endpoint` の直近ログを確認


### PR DESCRIPTION
## Summary

- Claude Code から llmlb `/v1/messages` 利用時に発生した `502 OpenAI-compatible upstream request failed` の調査結果を `memory/lessons.md` に教訓として追記し、同種の誤診断を防ぐ
- 根本原因は LM Studio エンドポイントの `inference_timeout_secs=120` 不足（コード不具合ではない）
- 追加で、pre-push の `cargo audit` で検出された 2 件の advisory への短期対応を同梱する（rustls-webpki 更新／rand advisory は恒久対応を #630 で追跡）

## Changes

- `memory/lessons.md`: 教訓 2 件を追加
  - 「エンドポイントのヘルスチェック Online は推論成功を意味しない」（事象・原因・再発防止・次回チェック）
  - 「Anthropic 502 レスポンスの message はハードコードで、実エラーは握りつぶされる」（事象・原因・再発防止・次回チェック）
- `Cargo.lock`: `rustls-webpki` を 0.103.12 → 0.103.13 に更新
  - RUSTSEC-2026-0104（certificate revocation list parsing の reachable panic、2026-04-22 公開）の upstream fix を取り込み
- `.cargo/audit.toml`: RUSTSEC-2026-0097 (rand 0.10.0 unsound) を一時 ignore
  - 恒久対応は #630 で追跡

## Testing

- [x] `cargo fmt --check` — OK
- [x] `cargo clippy -- -D warnings` — 警告なしで完走
- [x] `cargo test --workspace -- --test-threads=1` — 2798 passed; 0 failed; 3 ignored
- [x] `pnpm dlx markdownlint-cli2 "**/*.md" ...` — 0 error
- [x] `cargo audit` — 脆弱性なし（allowed warnings のみ）
- [x] `bash scripts/checks/check-commits.sh --from origin/develop --to HEAD` — 3/3 commit 合格
- [x] pre-push フック（husky `make quality-checks`）で `make quality-checks` 一式

## Closing Issues

- None

## Related Issues / Links

- #575 SPEC: OpenAI互換APIゲートウェイ（US-006 Anthropic Messages API）
- #628 `bug(anthropic): /v1/messages の 502 レスポンスでハードコード文字列が実エラーを握りつぶす`
- #629 `feature(endpoints): endpoint_type 別の既定 inference_timeout_secs 見直しと登録 UX 改善`
- #630 `chore(security): RUSTSEC-2026-0097 rand 0.10.0 unsound の恒久対応`

## Checklist

- [x] Tests added/updated — doc + deps 変更のためテスト追加なし（既存スイート 2798 件を回帰確認）
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, markdownlint)
- [x] Documentation updated (if user-facing change) — `memory/lessons.md` を追記
- [x] Migration/backfill plan included (if schema/data change) — スキーマ変更なしのため不要
- [x] CHANGELOG impact considered (breaking change flagged in commit) — doc + deps のみで CHANGELOG 影響なし、SemVer バンプ不要

## Context

- 観測事象: Claude Code v2.1.116 で `POST /v1/messages` が `API Error: 502 OpenAI-compatible upstream request failed` を連続返却
- 診断: llmlb ダッシュボードの Endpoints / History で BUILD-MAC-026 (LM Studio) の成功率 2.5%、Duration 2.0m（=120s）を確認
- 根本原因: 20B モデルのコールドロードに既定 `inference_timeout_secs=120` が足りず reqwest `send()` タイムアウト → `forward_to_endpoint` Err → `anthropic.rs:500-504` のハードコード文字列で 502 応答
- 対処方針:
  - 即時復旧はユーザー側の timeout 引き上げ + LM Studio のモデル事前ロード（コード変更不要）
  - 副次的な UX 問題は #628 / #629 として別 PR で対応
  - 本 PR は教訓の永続化のみに留める（＋ pre-push を通すための短期 audit 対応）

## Notes

- 本ブランチ名 `bugfix/local-llm-not-working` だが、コード不具合ではなく設定不足だったため `bugfix(*)` コミットにはせず `docs(lessons):` を主軸にしている
- `PLANS.md` は `.gitignore` 管理のため本 PR に含めない
- `cargo audit` の ignore は一時運用で、#630 のマージ時に元に戻す予定
