### PR TITLE
fix(api): /v1/models OpenAI互換準拠を補正 (#575 US-001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ heartbeats to the load balancer (there is no `POST /api/health`).
 LLM Load Balancer routes requests across registered inference endpoints and optionally proxies to
 cloud LLM providers via model prefixes.
 
+Related documents:
+
+- [`docs/architecture.md`](docs/architecture.md) — Detailed component design.
+- [`docs/model-catalog-policy.md`](docs/model-catalog-policy.md) — Catalog operation policy
+  (alias naming, canonical resolution, max_tokens fallback, quantization suffix policy).
+
 ### Components
 - **LLM Load Balancer (Rust)**: Receives OpenAI-compatible traffic, chooses a path, and proxies requests. Exposes dashboard, metrics, and admin APIs.
 - **Registered Endpoints**: LM Studio, Ollama, vLLM, xLLM, llama.cpp, and other OpenAI-compatible servers registered with the load balancer.

--- a/docs/model-catalog-policy.md
+++ b/docs/model-catalog-policy.md
@@ -1,0 +1,110 @@
+# モデルカタログ運用ポリシー
+
+`/v1/models` レスポンスにおける `id` / `canonical_name` / `aliases` / `max_tokens` /
+`supported_apis` 等の挙動と、`llmlb/src/models/mapping.rs` のメンテナンス指針を定める。
+
+本書は SPEC #575 「OpenAI互換APIゲートウェイ」US-001 の補正対応で発見された
+メタデータ品質課題（B-1〜B-5、G-1〜G-7）を踏まえた運用方針である。
+
+## エイリアス命名規則
+
+`BUILTIN_MAPPINGS` (`llmlb/src/models/mapping.rs`) の `aliases` には、各エンドポイント
+タイプ（Ollama / LM Studio / xLLM など）が利用するモデル名をすべて列挙する。
+
+ルール:
+
+- canonical 名は HuggingFace 上で**実在するリポジトリ ID** を採用する（例:
+  `zai-org/glm-4.7-flash`、`openai/gpt-oss-20b`）。組織名が変わったモデルでは、
+  旧 org の表記を alias として残す（例: `THUDM/glm-4.7-flash` → alias）。
+- alias 名は **各エンドポイントタイプ固有の命名形式** に従う。
+  - Ollama: `family:tag`（例: `gpt-oss:20b`、`gemma4`）
+  - LM Studio: HuggingFace 形式（例: `openai/gpt-oss-20b`）
+- `:latest` のような **可変タグは alias に含めない**。世代交代でルックアップ先が
+  ねじれて、後方互換性を壊すため（例: `gemma4:latest` を撤廃）。
+- 量子化サフィックス（`:Q4_K_M` など）は現状 ID に同居しているケースがあるが、
+  正規化方針は別 SPEC で扱う（後述「量子化サフィックス方針」）。
+
+## canonical_name の解決とフォールバック
+
+`CanonicalResolution::canonical_for(model_key)` は次の順で解決する。
+
+1. `model_key` 自身が canonical テーブルに登録 → そのまま返す。
+2. `model_to_canonical` 逆引きで対応する canonical を返す。
+3. いずれも未登録 → **`model_key` 自身を canonical として返す**（self-fallback）。
+
+「mapping に登録があるか？」の判定が必要な場合は `CanonicalResolution::is_known()`
+を併用する。`canonical_for` は `String` を必ず返す（`null` を返さない）。
+
+## max_tokens フォールバック（B-1 / G-7）
+
+`/v1/models` の `max_tokens` は次の優先順で解決する（`llmlb/src/models/mapping.rs:resolve_max_tokens`）。
+
+1. エンドポイント側 `/v1/models` が申告した `max_tokens`。
+2. `KNOWN_CONTEXT_LENGTHS` テーブルから canonical 一致で取得。
+3. いずれにも該当なし → `null`。
+
+`KNOWN_CONTEXT_LENGTHS` には公開情報（HuggingFace モデルカード等）から確認できた
+モデルの context length のみを登録する。バリエーションごとに異なる値が公称される
+モデル（量子化バリエーションで差がある等）は登録しない。
+
+新しいモデルを追加する際は出典（HF README / 公式リリースノート等）を PR 説明に
+記載する。
+
+## SKU 命名と派生バリエーション（G-2）
+
+ggml-org のように community 配布版のリポジトリは、独自 SKU 接頭辞（`E2B`、`E4B`
+等）を付ける場合がある。これらは公式の SKU と区別される派生で、自動的な canonical
+集約はしない方針。必要なら個別に `BUILTIN_MAPPINGS` に登録する。
+
+例:
+
+- `ggml-org/gemma-4-E2B-it-GGUF`: ggml-org community エッジ派生（仮）
+- `google/gemma-4-26b-a4b`: Google 公式の MoE 版（実在性は別途確認）
+
+派生バリエーションは「同じ世代の別 SKU」として扱う。利用者には UI/ドキュメントで
+派生関係を明示する（dashboard 側の表示改善は別 SPEC）。
+
+## 量子化サフィックス方針（G-3、暫定）
+
+現状、モデル ID には量子化サフィックス（`:Q4_K_M`、`:Q5_K_M`、`:Q8_0` 等）が
+含まれるケースと含まれないケースが混在する。本書執筆時点では**現状を維持**し、
+構造的な分離（`id` と `quantization` フィールドへの分割）は別 SPEC で扱う。
+
+**暫定運用**:
+
+- `BUILTIN_MAPPINGS` に登録する canonical は **量子化サフィックス無し** の repo ID
+  を優先する（例: `ggml-org/gemma-4-E4B-it-GGUF`）。
+- 同一 repo の異なる量子化を別エントリで列挙することは、可能な限り避ける。
+- エンドポイントが量子化サフィックス付き ID を申告してきた場合、self-canonical
+  fallback により `canonical_name` には ID 自身が入る（mapping 不在のため）。
+  恒久対応は `quantization` フィールド分離 SPEC を待つ。
+
+## 異常検知ログ（C-defensive）
+
+`EndpointRegistry::sync_models()` は単一エンドポイントが
+`SUSPICIOUS_MODEL_COUNT_THRESHOLD`（既定 50）件超のモデルを申告した場合に
+`tracing::warn!()` を出力する。これは「カタログ集約サーバが実体を持たない全モデルを
+`/v1/models` で返してしまう」誤申告（C-1 / C-2 / G-6 で観測）を運用者が早期に
+気付くための観測ポイント。
+
+## `lifecycle_status` / `download_progress` の扱い（B-4）
+
+両フィールドは現状ダッシュボード UI（`ModelsTable.tsx`）が消費している。値は
+ほぼ常に `Registered` / `null` だが、UI 連動のため API レスポンスからは削除しない。
+状態管理を実装するか、フィールドそのものを廃止するかは別 SPEC で扱う。
+
+## 別 SPEC へ送る項目（このブランチでは扱わない）
+
+- B-4: `lifecycle_status` / `download_progress` の挙動見直し（UI 連動の影響範囲が広い）
+- G-1: ggml-org gemma-4-E2B/E4B の canonical 追加（Gemma 4 系 SKU の実在性確認 G-5 が前提）
+- G-3: 量子化サフィックス命名規則の構造変更（`id` ↔ `quantization` 分離は API 互換性影響あり）
+- G-5: Gemma 4 SKU 実在性の事実確認（外部リソース照合）
+- C-1 / C-2 / G-6: 単一エンドポイントの大量モデル誤申告の根本対応（エンドポイント側設定）
+- C-3: モデル名妥当性の事実確認（外部リソース照合）
+
+## 関連リンク
+
+- 設計概要: [`architecture.md`](./architecture.md)
+- mapping 実装: `llmlb/src/models/mapping.rs`
+- /v1/models 実装: `llmlb/src/api/openai.rs` (`list_models`, `get_model`)
+- 関連 Issue: [#575 OpenAI互換APIゲートウェイ](https://github.com/akiojin/llmlb/issues/575)

--- a/docs/model-catalog-policy.md
+++ b/docs/model-catalog-policy.md
@@ -64,20 +64,41 @@ ggml-org のように community 配布版のリポジトリは、独自 SKU 接�
 派生バリエーションは「同じ世代の別 SKU」として扱う。利用者には UI/ドキュメントで
 派生関係を明示する（dashboard 側の表示改善は別 SPEC）。
 
-## 量子化サフィックス方針（G-3、暫定）
+## 量子化サフィックス方針（G-3、暫定実装済み）
 
-現状、モデル ID には量子化サフィックス（`:Q4_K_M`、`:Q5_K_M`、`:Q8_0` 等）が
-含まれるケースと含まれないケースが混在する。本書執筆時点では**現状を維持**し、
-構造的な分離（`id` と `quantization` フィールドへの分割）は別 SPEC で扱う。
+モデル ID には量子化サフィックス（`:Q4_K_M`、`:Q5_K_M`、`:Q8_0`、`:F16`、
+`:IQ4_XS` 等）が含まれるケースと含まれないケースが混在する。後方互換性のため
+**ID 自体は変更せず**、`/v1/models` レスポンスに新フィールド `quantization` を
+追加して情報を別出しする方針を採用する。
 
-**暫定運用**:
+### 実装（`llmlb/src/models/mapping.rs`）
 
-- `BUILTIN_MAPPINGS` に登録する canonical は **量子化サフィックス無し** の repo ID
-  を優先する（例: `ggml-org/gemma-4-E4B-it-GGUF`）。
-- 同一 repo の異なる量子化を別エントリで列挙することは、可能な限り避ける。
-- エンドポイントが量子化サフィックス付き ID を申告してきた場合、self-canonical
-  fallback により `canonical_name` には ID 自身が入る（mapping 不在のため）。
-  恒久対応は `quantization` フィールド分離 SPEC を待つ。
+- `split_quantization_suffix(model_id) -> (&str, Option<&str>)`:
+  - `:Q[0-9]*`、`:IQ[0-9]*`、`:F16` / `:F32` / `:BF16` / `:FP16` / `:FP32` /
+    `:F8E4M3FN` / `:F8E5M2` のいずれかにマッチした場合のみ suffix を分離。
+  - Ollama 形式タグ（`:30b`、`:latest` 等）は誤検出しない。
+- `CanonicalResolution::canonical_for(model_key)`:
+  - 通常の lookup → 量子化サフィックスを除去した base での再 lookup → self-fallback
+    の順で解決。これにより `ggml-org/repo:Q4_K_M` も `BUILTIN_MAPPINGS` に登録した
+    base 名（`ggml-org/repo`）から canonical を引ける。
+
+### レスポンスフィールド
+
+```text
+{
+  "id": "ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M",   // 互換のため変更しない
+  "quantization": "Q4_K_M",                       // 新フィールド（追加）
+  ...
+}
+```
+
+量子化サフィックスを持たないモデルは `quantization: null`。
+
+### 構造的分離（後方互換性影響あり）について
+
+「`id` を量子化なしへ正規化し、エンドポイントへのルーティング時に `quantization`
+を別経路で扱う」構造的分離はクライアント・dashboard・OpenAI 互換契約への影響が
+大きいため、この PR では扱わず別 SPEC（要 Issue 起票）で扱う。
 
 ## 異常検知ログ（C-defensive）
 
@@ -96,10 +117,10 @@ ggml-org のように community 配布版のリポジトリは、独自 SKU 接�
 ## 別 SPEC へ送る項目（このブランチでは扱わない）
 
 - B-4: `lifecycle_status` / `download_progress` の挙動見直し（UI 連動の影響範囲が広い）
-- G-1: ggml-org gemma-4-E2B/E4B の canonical 追加（Gemma 4 系 SKU の実在性確認 G-5 が前提）
-- G-3: 量子化サフィックス命名規則の構造変更（`id` ↔ `quantization` 分離は API 互換性影響あり）
+- G-1: ggml-org gemma-4-E2B/E4B の canonical 追加（Gemma 4 系 SKU の実在性確認 G-5 が前提。本書時点では self-canonical fallback で `canonical_name` に id 自身が入る暫定動作）
+- G-3 構造分離: `id` から量子化部分を除去し別経路でルーティングする破壊的変更（本書時点では `quantization` フィールド追加で情報の別出しまで実施）
 - G-5: Gemma 4 SKU 実在性の事実確認（外部リソース照合）
-- C-1 / C-2 / G-6: 単一エンドポイントの大量モデル誤申告の根本対応（エンドポイント側設定）
+- C-1 / C-2 / G-6: 単一エンドポイントの大量モデル誤申告の根本対応（エンドポイント側設定。本書時点では sync_models() の警告ログで早期検知のみ）
 - C-3: モデル名妥当性の事実確認（外部リソース照合）
 
 ## 関連リンク
@@ -107,4 +128,5 @@ ggml-org のように community 配布版のリポジトリは、独自 SKU 接�
 - 設計概要: [`architecture.md`](./architecture.md)
 - mapping 実装: `llmlb/src/models/mapping.rs`
 - /v1/models 実装: `llmlb/src/api/openai.rs` (`list_models`, `get_model`)
-- 関連 Issue: [#575 OpenAI互換APIゲートウェイ](https://github.com/akiojin/llmlb/issues/575)
+- 親 SPEC: [#575 OpenAI互換APIゲートウェイ](https://github.com/akiojin/llmlb/issues/575)
+- Follow-up Issue: [#643 /v1/models 品質改善: 残課題](https://github.com/akiojin/llmlb/issues/643)

--- a/llmlb/src/api/dashboard.rs
+++ b/llmlb/src/api/dashboard.rs
@@ -1084,6 +1084,8 @@ pub async fn get_models(State(state): State<AppState>) -> Result<Response, AppEr
             &canonical_name,
             endpoint_model_max_tokens.get(model_id).copied().flatten(),
         );
+        let (_, quantization) = crate::models::mapping::split_quantization_suffix(model_id);
+        let quantization = quantization.map(|s| s.to_string());
 
         if let Some(m) = registered_map.get(model_id) {
             let caps: crate::types::model::ModelCapabilities = m.get_capabilities().into();
@@ -1106,6 +1108,7 @@ pub async fn get_models(State(state): State<AppState>) -> Result<Response, AppEr
                 "chat_template": m.chat_template,
                 "supported_apis": supported_apis,
                 "max_tokens": max_tokens,
+                "quantization": quantization,
                 "endpoint_ids": endpoint_ids,
                 "canonical_name": canonical_name,
                 "aliases": aliases,
@@ -1121,6 +1124,7 @@ pub async fn get_models(State(state): State<AppState>) -> Result<Response, AppEr
                 "ready": ready,
                 "supported_apis": supported_apis,
                 "max_tokens": max_tokens,
+                "quantization": quantization,
                 "endpoint_ids": endpoint_ids,
                 "canonical_name": canonical_name,
                 "aliases": aliases,
@@ -1149,6 +1153,8 @@ pub async fn get_models(State(state): State<AppState>) -> Result<Response, AppEr
             &canonical_name,
             endpoint_model_max_tokens.get(model_id).copied().flatten(),
         );
+        let (_, quantization) = crate::models::mapping::split_quantization_suffix(model_id);
+        let quantization = quantization.map(|s| s.to_string());
         data.push(json!({
             "id": model_id,
             "object": "model",
@@ -1159,6 +1165,7 @@ pub async fn get_models(State(state): State<AppState>) -> Result<Response, AppEr
             "ready": ready_models.contains(model_id),
             "supported_apis": supported_apis,
             "max_tokens": max_tokens,
+            "quantization": quantization,
             "endpoint_ids": endpoint_ids,
             "canonical_name": canonical_name,
             "aliases": aliases,

--- a/llmlb/src/api/dashboard.rs
+++ b/llmlb/src/api/dashboard.rs
@@ -1080,6 +1080,10 @@ pub async fn get_models(State(state): State<AppState>) -> Result<Response, AppEr
 
         let aliases = canonical_resolution.aliases_for(model_id);
         let canonical_name = canonical_resolution.canonical_for(model_id);
+        let max_tokens = crate::models::mapping::resolve_max_tokens(
+            &canonical_name,
+            endpoint_model_max_tokens.get(model_id).copied().flatten(),
+        );
 
         if let Some(m) = registered_map.get(model_id) {
             let caps: crate::types::model::ModelCapabilities = m.get_capabilities().into();
@@ -1101,7 +1105,7 @@ pub async fn get_models(State(state): State<AppState>) -> Result<Response, AppEr
                 "description": m.description,
                 "chat_template": m.chat_template,
                 "supported_apis": supported_apis,
-                "max_tokens": endpoint_model_max_tokens.get(model_id).copied().flatten(),
+                "max_tokens": max_tokens,
                 "endpoint_ids": endpoint_ids,
                 "canonical_name": canonical_name,
                 "aliases": aliases,
@@ -1116,7 +1120,7 @@ pub async fn get_models(State(state): State<AppState>) -> Result<Response, AppEr
                 "download_progress": null,
                 "ready": ready,
                 "supported_apis": supported_apis,
-                "max_tokens": endpoint_model_max_tokens.get(model_id).copied().flatten(),
+                "max_tokens": max_tokens,
                 "endpoint_ids": endpoint_ids,
                 "canonical_name": canonical_name,
                 "aliases": aliases,
@@ -1141,6 +1145,10 @@ pub async fn get_models(State(state): State<AppState>) -> Result<Response, AppEr
             .unwrap_or_default();
         let aliases = canonical_resolution.aliases_for(model_id);
         let canonical_name = canonical_resolution.canonical_for(model_id);
+        let max_tokens = crate::models::mapping::resolve_max_tokens(
+            &canonical_name,
+            endpoint_model_max_tokens.get(model_id).copied().flatten(),
+        );
         data.push(json!({
             "id": model_id,
             "object": "model",
@@ -1150,7 +1158,7 @@ pub async fn get_models(State(state): State<AppState>) -> Result<Response, AppEr
             "download_progress": null,
             "ready": ready_models.contains(model_id),
             "supported_apis": supported_apis,
-            "max_tokens": endpoint_model_max_tokens.get(model_id).copied().flatten(),
+            "max_tokens": max_tokens,
             "endpoint_ids": endpoint_ids,
             "canonical_name": canonical_name,
             "aliases": aliases,

--- a/llmlb/src/api/openai.rs
+++ b/llmlb/src/api/openai.rs
@@ -17,9 +17,15 @@ fn owned_by_from_id(id: &str) -> String {
 /// 登録済みモデルの capabilities とエンドポイント申告 supported_apis を統合し、
 /// `as_str()` 昇順で並べた `Vec<String>` を返す（OpenAI互換 /v1/models 用）。
 ///
-/// - 登録モデルの `ModelCapability` から SupportedAPI を導出（embedding 等の取りこぼし対策）。
-/// - capability マッピングが空の場合のみ、エンドポイント申告にフォールバック。
-/// - 出力は決定論的（HashSet 由来の非決定的順序を排除）。
+/// 解決順:
+/// 1. 登録モデルの `ModelCapability` から導出した SupportedAPI を加算する
+///    （A-1: embedding capability の取りこぼし対策）。
+/// 2. **常に** endpoint_reported もマージする。`ModelInfo::get_capabilities()` は
+///    メタデータが空のレガシー行に対して `[TextGeneration]` を既定で返すため、
+///    capability 由来の set が非空でも endpoint がサポートする `embeddings` 等を
+///    取りこぼさないように両者をマージする（CodeRabbit/Codex review #642 対応）。
+/// 3. 双方が何も寄与しなければ `ChatCompletions` のフォールバック。
+/// 4. 最後に `as_str()` 昇順で並べて決定論化する（A-3）。
 fn build_supported_apis(
     model: Option<&crate::registry::models::ModelInfo>,
     endpoint_reported: Option<&std::collections::HashSet<crate::types::endpoint::SupportedAPI>>,
@@ -42,15 +48,13 @@ fn build_supported_apis(
             }
         }
     }
+    if let Some(reported) = endpoint_reported {
+        for api in reported {
+            set.insert(*api);
+        }
+    }
     if set.is_empty() {
-        if let Some(reported) = endpoint_reported {
-            for api in reported {
-                set.insert(*api);
-            }
-        }
-        if set.is_empty() {
-            set.insert(SupportedAPI::ChatCompletions);
-        }
+        set.insert(SupportedAPI::ChatCompletions);
     }
     let mut v: Vec<SupportedAPI> = set.into_iter().collect();
     v.sort_by_key(|a| a.as_str());
@@ -4069,6 +4073,59 @@ mod tests {
         assert!(apis.contains(&"chat_completions"));
         assert!(apis.contains(&"embeddings"));
         assert!(apis.contains(&"responses"));
+        std::env::remove_var("LLMLB_DATA_DIR");
+    }
+
+    /// Regression: capability 由来 set が非空でも endpoint_reported が必ずマージされること
+    /// （review #642 — ModelInfo がレガシー行で `[TextGeneration]` を既定返却することにより
+    /// endpoint が報告する `embeddings` 等が取りこぼされていた問題の検証）
+    #[tokio::test]
+    #[serial]
+    async fn list_models_endpoint_apis_are_merged_even_when_model_capabilities_default() {
+        use crate::registry::models::ModelInfo;
+        use crate::types::endpoint::SupportedAPI;
+
+        let _guard = TEST_LOCK.lock().await;
+        let (state, _dir) = create_state_with_tempdir().await;
+
+        // capabilities を明示せず登録（=> get_capabilities() は [TextGeneration] を既定返却）
+        let model = ModelInfo::new(
+            "vendor/legacy-row".to_string(),
+            0,
+            "legacy registration without capabilities".to_string(),
+            0,
+            vec![],
+        );
+        let storage = crate::db::models::ModelStorage::new(state.db_pool.clone());
+        storage.save_model(&model).await.expect("save model");
+
+        // endpoint は Embeddings をサポートしている（実態を申告）
+        add_endpoint_with_supported_apis(
+            &state,
+            "embed-endpoint",
+            "vendor/legacy-row",
+            vec![SupportedAPI::Embeddings],
+        )
+        .await;
+
+        let body = fetch_list_models(state).await;
+        let data = body["data"].as_array().expect("data array");
+        let model = data
+            .iter()
+            .find(|m| m["id"].as_str() == Some("vendor/legacy-row"))
+            .expect("model in /v1/models");
+
+        let apis: Vec<&str> = model["supported_apis"]
+            .as_array()
+            .expect("supported_apis array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(
+            apis.contains(&"embeddings"),
+            "endpoint-reported `embeddings` must not be dropped even when capability-derived set is non-empty (got: {:?})",
+            apis
+        );
         std::env::remove_var("LLMLB_DATA_DIR");
     }
 

--- a/llmlb/src/api/openai.rs
+++ b/llmlb/src/api/openai.rs
@@ -423,6 +423,9 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Response, AppE
             &canonical_name,
             endpoint_model_max_tokens.get(model_id).copied().flatten(),
         );
+        // 量子化サフィックスを ID から分離（G-3 暫定: ID は維持しつつ別フィールドへ出す）
+        let (_, quantization) = crate::models::mapping::split_quantization_suffix(model_id);
+        let quantization = quantization.map(|s| s.to_string());
 
         if let Some(m) = registered_map.get(model_id) {
             let caps: ModelCapabilities = m.get_capabilities().into();
@@ -449,6 +452,7 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Response, AppE
                 "chat_template": m.chat_template,
                 "supported_apis": supported_apis,
                 "max_tokens": max_tokens,
+                "quantization": quantization,
                 "endpoint_ids": endpoint_ids,
                 "canonical_name": canonical_name,
                 "aliases": aliases,
@@ -465,6 +469,7 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Response, AppE
                 "ready": ready,
                 "supported_apis": supported_apis,
                 "max_tokens": max_tokens,
+                "quantization": quantization,
                 "endpoint_ids": endpoint_ids,
                 "canonical_name": canonical_name,
                 "aliases": aliases,
@@ -4064,6 +4069,76 @@ mod tests {
         assert!(apis.contains(&"chat_completions"));
         assert!(apis.contains(&"embeddings"));
         assert!(apis.contains(&"responses"));
+        std::env::remove_var("LLMLB_DATA_DIR");
+    }
+
+    /// G-3 暫定: 量子化サフィックス付きモデル ID から `quantization` フィールドが分離されること
+    #[tokio::test]
+    #[serial]
+    async fn list_models_quantization_suffix_is_emitted_as_separate_field() {
+        use crate::types::endpoint::{
+            Endpoint, EndpointModel, EndpointStatus, EndpointType, SupportedAPI,
+        };
+
+        let _guard = TEST_LOCK.lock().await;
+        let (state, _dir) = create_state_with_tempdir().await;
+
+        // 1 つのエンドポイントに「量子化付き」と「量子化なし」両方のモデルを登録して比較
+        let mut endpoint = Endpoint::new(
+            "quant-endpoint".to_string(),
+            "http://127.0.0.1:0".to_string(),
+            EndpointType::OpenaiCompatible,
+        );
+        endpoint.status = EndpointStatus::Online;
+        let endpoint_id = endpoint.id;
+        state
+            .endpoint_registry
+            .add(endpoint)
+            .await
+            .expect("add endpoint");
+        for model_id in ["ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M", "openai/gpt-oss-20b"] {
+            state
+                .endpoint_registry
+                .add_model(&EndpointModel {
+                    endpoint_id,
+                    model_id: model_id.to_string(),
+                    capabilities: None,
+                    max_tokens: None,
+                    last_checked: None,
+                    supported_apis: vec![SupportedAPI::ChatCompletions],
+                    canonical_name: None,
+                })
+                .await
+                .expect("add endpoint model");
+        }
+
+        let body = fetch_list_models(state).await;
+        let data = body["data"].as_array().expect("data array");
+
+        let gguf = data
+            .iter()
+            .find(|m| m["id"].as_str() == Some("ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M"))
+            .expect("gguf model in /v1/models");
+        assert_eq!(
+            gguf["quantization"].as_str(),
+            Some("Q4_K_M"),
+            "quantization suffix must be emitted as separate field"
+        );
+        assert_eq!(
+            gguf["id"].as_str(),
+            Some("ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M"),
+            "id must remain unchanged for backward compatibility"
+        );
+
+        let plain = data
+            .iter()
+            .find(|m| m["id"].as_str() == Some("openai/gpt-oss-20b"))
+            .expect("non-gguf model in /v1/models");
+        assert!(
+            plain["quantization"].is_null(),
+            "non-quantized model must report quantization: null (got: {:?})",
+            plain["quantization"]
+        );
         std::env::remove_var("LLMLB_DATA_DIR");
     }
 

--- a/llmlb/src/api/openai.rs
+++ b/llmlb/src/api/openai.rs
@@ -416,8 +416,13 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Response, AppE
 
         // エイリアス情報を取得
         let aliases = canonical_resolution.aliases_for(model_id);
-        // canonical_nameを取得（表示用）
+        // canonical_nameを取得（self-fallback により null は返らない）
         let canonical_name = canonical_resolution.canonical_for(model_id);
+        // max_tokens: endpoint 申告 → 既知 canonical テーブルの順で解決
+        let max_tokens = crate::models::mapping::resolve_max_tokens(
+            &canonical_name,
+            endpoint_model_max_tokens.get(model_id).copied().flatten(),
+        );
 
         if let Some(m) = registered_map.get(model_id) {
             let caps: ModelCapabilities = m.get_capabilities().into();
@@ -443,7 +448,7 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Response, AppE
                 "description": m.description,
                 "chat_template": m.chat_template,
                 "supported_apis": supported_apis,
-                "max_tokens": endpoint_model_max_tokens.get(model_id).copied().flatten(),
+                "max_tokens": max_tokens,
                 "endpoint_ids": endpoint_ids,
                 "canonical_name": canonical_name,
                 "aliases": aliases,
@@ -459,7 +464,7 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Response, AppE
                 "download_progress": null,
                 "ready": ready,
                 "supported_apis": supported_apis,
-                "max_tokens": endpoint_model_max_tokens.get(model_id).copied().flatten(),
+                "max_tokens": max_tokens,
                 "endpoint_ids": endpoint_ids,
                 "canonical_name": canonical_name,
                 "aliases": aliases,
@@ -4059,6 +4064,55 @@ mod tests {
         assert!(apis.contains(&"chat_completions"));
         assert!(apis.contains(&"embeddings"));
         assert!(apis.contains(&"responses"));
+        std::env::remove_var("LLMLB_DATA_DIR");
+    }
+
+    /// B-1/G-7: endpoint が max_tokens を申告しない場合に既知 canonical テーブルから補填すること
+    #[tokio::test]
+    #[serial]
+    async fn list_models_max_tokens_falls_back_to_known_canonical_table() {
+        use crate::registry::models::ModelInfo;
+        use crate::types::endpoint::SupportedAPI;
+
+        let _guard = TEST_LOCK.lock().await;
+        let (state, _dir) = create_state_with_tempdir().await;
+
+        // 既知 canonical のモデルを登録（テーブルには 131072 がある）
+        let model = ModelInfo::new(
+            "openai/gpt-oss-20b".to_string(),
+            0,
+            "test".to_string(),
+            0,
+            vec![],
+        );
+        let storage = crate::db::models::ModelStorage::new(state.db_pool.clone());
+        storage.save_model(&model).await.expect("save model");
+
+        // endpoint は max_tokens を申告しない（add_endpoint_with_supported_apis のヘルパは
+        // EndpointModel.max_tokens=None で登録する）
+        add_endpoint_with_supported_apis(
+            &state,
+            "fallback-endpoint",
+            "openai/gpt-oss-20b",
+            vec![SupportedAPI::ChatCompletions],
+        )
+        .await;
+
+        let body = fetch_list_models(state).await;
+        let data = body["data"].as_array().expect("data array");
+        let model = data
+            .iter()
+            .find(|m| m["id"].as_str() == Some("openai/gpt-oss-20b"))
+            .expect("model in /v1/models");
+
+        let max_tokens = model["max_tokens"]
+            .as_u64()
+            .expect("max_tokens fallback applied");
+        assert_eq!(
+            max_tokens, 131_072,
+            "max_tokens must fall back to KNOWN_CONTEXT_LENGTHS for known canonical (got: {})",
+            max_tokens
+        );
         std::env::remove_var("LLMLB_DATA_DIR");
     }
 

--- a/llmlb/src/api/openai.rs
+++ b/llmlb/src/api/openai.rs
@@ -5,6 +5,58 @@
 /// 未指定/仮想IPアドレス（クラウドプロバイダ等、実IPを持たない場合に使用）
 const UNSPECIFIED_IP: std::net::IpAddr = std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED);
 
+/// `id` の組織プレフィックス（"org/name" の "org"）を `owned_by` として返す。
+/// スラッシュがない場合は "load balancer" にフォールバック。
+fn owned_by_from_id(id: &str) -> String {
+    match id.split_once('/') {
+        Some((org, _)) if !org.is_empty() => org.to_string(),
+        _ => "load balancer".to_string(),
+    }
+}
+
+/// 登録済みモデルの capabilities とエンドポイント申告 supported_apis を統合し、
+/// `as_str()` 昇順で並べた `Vec<String>` を返す（OpenAI互換 /v1/models 用）。
+///
+/// - 登録モデルの `ModelCapability` から SupportedAPI を導出（embedding 等の取りこぼし対策）。
+/// - capability マッピングが空の場合のみ、エンドポイント申告にフォールバック。
+/// - 出力は決定論的（HashSet 由来の非決定的順序を排除）。
+fn build_supported_apis(
+    model: Option<&crate::registry::models::ModelInfo>,
+    endpoint_reported: Option<&std::collections::HashSet<crate::types::endpoint::SupportedAPI>>,
+) -> Vec<String> {
+    use crate::types::endpoint::SupportedAPI;
+    use std::collections::HashSet;
+
+    let mut set: HashSet<SupportedAPI> = HashSet::new();
+    if let Some(m) = model {
+        for cap in m.get_capabilities() {
+            match cap {
+                ModelCapability::TextGeneration => {
+                    set.insert(SupportedAPI::ChatCompletions);
+                    set.insert(SupportedAPI::Responses);
+                }
+                ModelCapability::Embedding => {
+                    set.insert(SupportedAPI::Embeddings);
+                }
+                _ => {}
+            }
+        }
+    }
+    if set.is_empty() {
+        if let Some(reported) = endpoint_reported {
+            for api in reported {
+                set.insert(*api);
+            }
+        }
+        if set.is_empty() {
+            set.insert(SupportedAPI::ChatCompletions);
+        }
+    }
+    let mut v: Vec<SupportedAPI> = set.into_iter().collect();
+    v.sort_by_key(|a| a.as_str());
+    v.into_iter().map(|a| a.as_str().to_string()).collect()
+}
+
 use crate::common::{
     error::{CommonError, LbError},
     protocol::{RecordStatus, RequestResponseRecord, RequestType, TpsApiKind},
@@ -338,22 +390,21 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Response, AppE
     let available_set: std::collections::HashSet<String> =
         available_models.iter().cloned().collect();
 
-    // 追跡用：モデルID一覧
-    let mut seen_models: HashSet<String> = HashSet::new();
-
     // OpenAI互換レスポンス形式 + Azure capabilities + ダッシュボード拡張
     let mut data: Vec<Value> = Vec::new();
 
+    // 観測時刻（last_modified が無いモデルは観測時刻を created に採用）
+    let observed_now = chrono::Utc::now().timestamp();
+
     // ノードのモデルを追加
     for model_id in &available_models {
-        seen_models.insert(model_id.clone());
         let ready = available_set.contains(model_id);
 
-        // supported_apisを取得（デフォルトはchat_completions）
-        let supported_apis: Vec<String> = endpoint_model_apis
-            .get(model_id)
-            .map(|apis| apis.iter().map(|a| a.as_str().to_string()).collect())
-            .unwrap_or_else(|| vec!["chat_completions".to_string()]);
+        // supported_apis: 登録モデルの capability 由来 / エンドポイント申告 / フォールバックを統合し as_str() 昇順で返す
+        let supported_apis: Vec<String> = build_supported_apis(
+            registered_map.get(model_id),
+            endpoint_model_apis.get(model_id),
+        );
         let endpoint_ids: Vec<String> = endpoint_model_ids
             .get(model_id)
             .map(|ids| {
@@ -370,11 +421,15 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Response, AppE
 
         if let Some(m) = registered_map.get(model_id) {
             let caps: ModelCapabilities = m.get_capabilities().into();
+            let created = m
+                .last_modified
+                .map(|t| t.timestamp())
+                .unwrap_or(observed_now);
             let obj = json!({
                 "id": m.name,
                 "object": "model",
-                "created": 0,
-                "owned_by": "load balancer",
+                "created": created,
+                "owned_by": owned_by_from_id(&m.name),
                 "capabilities": caps,
                 "lifecycle_status": LifecycleStatus::Registered,
                 "download_progress": null,
@@ -398,8 +453,8 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Response, AppE
             let obj = json!({
                 "id": model_id,
                 "object": "model",
-                "created": 0,
-                "owned_by": "load balancer",
+                "created": observed_now,
+                "owned_by": owned_by_from_id(model_id),
                 "lifecycle_status": LifecycleStatus::Registered,
                 "download_progress": null,
                 "ready": ready,
@@ -413,36 +468,9 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Response, AppE
         }
     }
 
-    // SPEC-0f1de549: エンドポイント専用モデルを追加（ノードにないモデル）
-    for (model_id, apis) in &endpoint_model_apis {
-        if seen_models.contains(model_id) {
-            continue;
-        }
-        seen_models.insert(model_id.clone());
-
-        let supported_apis: Vec<String> = apis.iter().map(|a| a.as_str().to_string()).collect();
-        let endpoint_ids: Vec<String> = endpoint_model_ids
-            .get(model_id)
-            .map(|ids| {
-                let mut ids: Vec<String> = ids.iter().cloned().collect();
-                ids.sort();
-                ids
-            })
-            .unwrap_or_default();
-        let obj = json!({
-            "id": model_id,
-            "object": "model",
-            "created": 0,
-            "owned_by": "endpoint",
-            "lifecycle_status": LifecycleStatus::Registered,
-            "download_progress": null,
-            "ready": true,
-            "supported_apis": supported_apis,
-            "max_tokens": endpoint_model_max_tokens.get(model_id).copied().flatten(),
-            "endpoint_ids": endpoint_ids,
-        });
-        data.push(obj);
-    }
+    // NOTE: かつて存在した "endpoint_model_apis を再走査する" ループは
+    // available_models = endpoint_model_apis.keys() のため到達不能だった。
+    // 上の available_models ループで全件カバー済み。
 
     // NOTE: SPEC-6cd7f960 FR-6により、登録済みだがオンラインエンドポイントにないモデルは
     // /v1/models に含めない（利用可能なモデルのみを返す）
@@ -530,11 +558,10 @@ pub async fn get_model(
         return Ok((StatusCode::NOT_FOUND, Json(body)).into_response());
     }
 
-    // supported_apisを取得（デフォルトはchat_completions）
-    let supported_apis: Vec<String> = endpoint_model_apis
-        .get(&model_id)
-        .map(|apis| apis.iter().map(|a| a.as_str().to_string()).collect())
-        .unwrap_or_else(|| vec!["chat_completions".to_string()]);
+    // supported_apis: 登録モデルの capability 由来 / エンドポイント申告 を統合し as_str() 昇順で返す
+    let supported_apis: Vec<String> =
+        build_supported_apis(model.as_ref(), endpoint_model_apis.get(&model_id));
+    let observed_now = chrono::Utc::now().timestamp();
 
     if let Some(model) = model {
         // Azure OpenAI 形式の capabilities (boolean object)
@@ -545,12 +572,16 @@ pub async fn get_model(
         } else {
             LifecycleStatus::Pending
         };
+        let created = model
+            .last_modified
+            .map(|t| t.timestamp())
+            .unwrap_or(observed_now);
 
         let body = json!({
             "id": model_id,
             "object": "model",
-            "created": 0,
-            "owned_by": "load balancer",
+            "created": created,
+            "owned_by": owned_by_from_id(&model_id),
             "capabilities": caps,
             // ダッシュボード用拡張フィールド
             "lifecycle_status": lifecycle_status,
@@ -570,20 +601,14 @@ pub async fn get_model(
         return Ok((StatusCode::OK, Json(body)).into_response());
     }
 
-    // エンドポイント専用モデルまたはノードのモデル（メタデータなし）
-    let owned_by = if is_endpoint_model {
-        "endpoint"
-    } else {
-        "load balancer"
-    };
-
+    // エンドポイント専用モデル（メタデータなし）
     let body = json!({
         "id": model_id,
         "object": "model",
-        "created": 0,
-        "owned_by": owned_by,
+        "created": observed_now,
+        "owned_by": owned_by_from_id(&model_id),
         "lifecycle_status": LifecycleStatus::Registered,
-        "ready": true,
+        "ready": is_endpoint_model,
         "supported_apis": supported_apis,
     });
 
@@ -3826,5 +3851,258 @@ mod tests {
             HeaderValue::from_static("for=unknown;proto=https"),
         );
         assert!(extract_client_ip_from_headers(&headers).is_none());
+    }
+
+    // ===== /v1/models response correction tests (#575 US-001 補正対応) =====
+
+    /// helper: 指定 supported_apis を申告するオンラインエンドポイントを登録する
+    async fn add_endpoint_with_supported_apis(
+        state: &AppState,
+        endpoint_name: &str,
+        model_id: &str,
+        apis: Vec<crate::types::endpoint::SupportedAPI>,
+    ) -> uuid::Uuid {
+        use crate::types::endpoint::{Endpoint, EndpointModel, EndpointStatus, EndpointType};
+        let mut endpoint = Endpoint::new(
+            endpoint_name.to_string(),
+            "http://127.0.0.1:0".to_string(),
+            EndpointType::OpenaiCompatible,
+        );
+        endpoint.status = EndpointStatus::Online;
+        let endpoint_id = endpoint.id;
+        state
+            .endpoint_registry
+            .add(endpoint)
+            .await
+            .expect("add endpoint");
+        state
+            .endpoint_registry
+            .add_model(&EndpointModel {
+                endpoint_id,
+                model_id: model_id.to_string(),
+                capabilities: None,
+                max_tokens: None,
+                last_checked: None,
+                supported_apis: apis,
+                canonical_name: None,
+            })
+            .await
+            .expect("add endpoint model");
+        endpoint_id
+    }
+
+    /// helper: list_models() を呼び出し、JSON ボディを返す
+    async fn fetch_list_models(state: AppState) -> serde_json::Value {
+        let resp = super::list_models(axum::extract::State(state))
+            .await
+            .expect("list_models ok");
+        let bytes = to_bytes(resp.into_body(), 1_000_000)
+            .await
+            .expect("read body");
+        serde_json::from_slice::<serde_json::Value>(&bytes).expect("parse json")
+    }
+
+    /// A-1 RED: 登録済み embedding モデルの supported_apis に "embeddings" が含まれること
+    #[tokio::test]
+    #[serial]
+    async fn list_models_embedding_capability_emits_embeddings_api() {
+        use crate::registry::models::ModelInfo;
+        use crate::types::endpoint::SupportedAPI;
+        use crate::types::ModelCapability;
+
+        let _guard = TEST_LOCK.lock().await;
+        let (state, _dir) = create_state_with_tempdir().await;
+
+        // embedding capability で登録
+        let mut model = ModelInfo::with_capabilities(
+            "nomic-ai/nomic-embed-text-v1.5".to_string(),
+            0,
+            "embedding model".to_string(),
+            0,
+            vec![],
+            vec![ModelCapability::Embedding],
+        );
+        model.repo = Some("nomic-ai/nomic-embed-text-v1.5".to_string());
+        let storage = crate::db::models::ModelStorage::new(state.db_pool.clone());
+        storage.save_model(&model).await.expect("save model");
+
+        // エンドポイントは ChatCompletions しか申告しない（実環境の典型ケース）
+        add_endpoint_with_supported_apis(
+            &state,
+            "embed-endpoint",
+            "nomic-ai/nomic-embed-text-v1.5",
+            vec![SupportedAPI::ChatCompletions],
+        )
+        .await;
+
+        let body = fetch_list_models(state).await;
+        let data = body["data"].as_array().expect("data array");
+        let model = data
+            .iter()
+            .find(|m| m["id"].as_str() == Some("nomic-ai/nomic-embed-text-v1.5"))
+            .expect("embedding model in /v1/models");
+
+        let apis: Vec<&str> = model["supported_apis"]
+            .as_array()
+            .expect("supported_apis array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(
+            apis.contains(&"embeddings"),
+            "embedding-capability model must report 'embeddings' in supported_apis (got: {:?})",
+            apis
+        );
+        std::env::remove_var("LLMLB_DATA_DIR");
+    }
+
+    /// A-2 RED: 登録済みモデルの created は last_modified の Unix epoch を反映すること
+    #[tokio::test]
+    #[serial]
+    async fn list_models_registered_created_reflects_last_modified() {
+        use crate::registry::models::ModelInfo;
+        use crate::types::endpoint::SupportedAPI;
+        use chrono::TimeZone;
+
+        let _guard = TEST_LOCK.lock().await;
+        let (state, _dir) = create_state_with_tempdir().await;
+
+        let known_ts = chrono::Utc.with_ymd_and_hms(2024, 6, 1, 12, 0, 0).unwrap();
+        let mut model = ModelInfo::new(
+            "vendor/known-time-model".to_string(),
+            0,
+            "test".to_string(),
+            0,
+            vec![],
+        );
+        model.last_modified = Some(known_ts);
+        let storage = crate::db::models::ModelStorage::new(state.db_pool.clone());
+        storage.save_model(&model).await.expect("save model");
+
+        add_endpoint_with_supported_apis(
+            &state,
+            "ts-endpoint",
+            "vendor/known-time-model",
+            vec![SupportedAPI::ChatCompletions],
+        )
+        .await;
+
+        let body = fetch_list_models(state).await;
+        let data = body["data"].as_array().expect("data array");
+        let model = data
+            .iter()
+            .find(|m| m["id"].as_str() == Some("vendor/known-time-model"))
+            .expect("model in /v1/models");
+
+        let created = model["created"].as_i64().expect("created is integer");
+        assert_eq!(
+            created,
+            known_ts.timestamp(),
+            "registered model created must reflect last_modified epoch (got: {})",
+            created
+        );
+        std::env::remove_var("LLMLB_DATA_DIR");
+    }
+
+    /// A-3 RED: supported_apis は as_str() 昇順で並ぶこと（決定論化）
+    #[tokio::test]
+    #[serial]
+    async fn list_models_supported_apis_are_sorted() {
+        use crate::registry::models::ModelInfo;
+        use crate::types::endpoint::SupportedAPI;
+        use crate::types::ModelCapability;
+
+        let _guard = TEST_LOCK.lock().await;
+        let (state, _dir) = create_state_with_tempdir().await;
+
+        // TextGeneration + Embedding の両対応モデル
+        let model = ModelInfo::with_capabilities(
+            "vendor/multi-cap".to_string(),
+            0,
+            "multi capability".to_string(),
+            0,
+            vec![],
+            vec![ModelCapability::TextGeneration, ModelCapability::Embedding],
+        );
+        let storage = crate::db::models::ModelStorage::new(state.db_pool.clone());
+        storage.save_model(&model).await.expect("save model");
+
+        add_endpoint_with_supported_apis(
+            &state,
+            "multi-endpoint",
+            "vendor/multi-cap",
+            vec![SupportedAPI::ChatCompletions, SupportedAPI::Embeddings],
+        )
+        .await;
+
+        let body = fetch_list_models(state).await;
+        let data = body["data"].as_array().expect("data array");
+        let model = data
+            .iter()
+            .find(|m| m["id"].as_str() == Some("vendor/multi-cap"))
+            .expect("multi-cap model in /v1/models");
+
+        let apis: Vec<&str> = model["supported_apis"]
+            .as_array()
+            .expect("supported_apis array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        let mut sorted = apis.clone();
+        sorted.sort();
+        assert_eq!(
+            apis, sorted,
+            "supported_apis must be in ascending lexicographic order (got: {:?})",
+            apis
+        );
+        // 期待される3要素を網羅していること（A-1 の効果も込み）
+        assert!(apis.contains(&"chat_completions"));
+        assert!(apis.contains(&"embeddings"));
+        assert!(apis.contains(&"responses"));
+        std::env::remove_var("LLMLB_DATA_DIR");
+    }
+
+    /// A-5 RED: owned_by は id の組織プレフィックス由来になること（"load balancer" 固定値からの脱却）
+    #[tokio::test]
+    #[serial]
+    async fn list_models_owned_by_uses_id_org_prefix() {
+        use crate::registry::models::ModelInfo;
+        use crate::types::endpoint::SupportedAPI;
+
+        let _guard = TEST_LOCK.lock().await;
+        let (state, _dir) = create_state_with_tempdir().await;
+
+        let model = ModelInfo::new(
+            "Qwen/Qwen3-Coder-30B-A3B-Instruct".to_string(),
+            0,
+            "test".to_string(),
+            0,
+            vec![],
+        );
+        let storage = crate::db::models::ModelStorage::new(state.db_pool.clone());
+        storage.save_model(&model).await.expect("save model");
+
+        add_endpoint_with_supported_apis(
+            &state,
+            "qwen-endpoint",
+            "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+            vec![SupportedAPI::ChatCompletions],
+        )
+        .await;
+
+        let body = fetch_list_models(state).await;
+        let data = body["data"].as_array().expect("data array");
+        let model = data
+            .iter()
+            .find(|m| m["id"].as_str() == Some("Qwen/Qwen3-Coder-30B-A3B-Instruct"))
+            .expect("model in /v1/models");
+
+        let owned_by = model["owned_by"].as_str().expect("owned_by string");
+        assert_eq!(
+            owned_by, "Qwen",
+            "owned_by must derive from id organization prefix (got: {})",
+            owned_by
+        );
+        std::env::remove_var("LLMLB_DATA_DIR");
     }
 }

--- a/llmlb/src/db/endpoints.rs
+++ b/llmlb/src/db/endpoints.rs
@@ -403,12 +403,13 @@ pub async fn add_endpoint_model(
         .capabilities
         .as_ref()
         .map(|c| serde_json::to_string(c).unwrap_or_default());
+    let supported_apis_json = serde_json::to_string(&model.supported_apis).unwrap_or_default();
     let last_checked = model.last_checked.map(|dt| dt.to_rfc3339());
 
     sqlx::query(
         r#"
-        INSERT OR REPLACE INTO endpoint_models (endpoint_id, model_id, capabilities, max_tokens, last_checked, canonical_name)
-        VALUES (?, ?, ?, ?, ?, ?)
+        INSERT OR REPLACE INTO endpoint_models (endpoint_id, model_id, capabilities, max_tokens, last_checked, supported_apis, canonical_name)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
         "#,
     )
     .bind(model.endpoint_id.to_string())
@@ -416,6 +417,7 @@ pub async fn add_endpoint_model(
     .bind(&capabilities_json)
     .bind(model.max_tokens.map(|v| v as i32))
     .bind(&last_checked)
+    .bind(&supported_apis_json)
     .bind(&model.canonical_name)
     .execute(pool)
     .await?;
@@ -432,17 +434,19 @@ pub async fn update_endpoint_model(
         .capabilities
         .as_ref()
         .map(|c| serde_json::to_string(c).unwrap_or_default());
+    let supported_apis_json = serde_json::to_string(&model.supported_apis).unwrap_or_default();
 
     let result = sqlx::query(
         r#"
         UPDATE endpoint_models
-        SET capabilities = ?, max_tokens = ?, last_checked = ?, canonical_name = ?
+        SET capabilities = ?, max_tokens = ?, last_checked = ?, supported_apis = ?, canonical_name = ?
         WHERE endpoint_id = ? AND model_id = ?
         "#,
     )
     .bind(&capabilities_json)
     .bind(model.max_tokens.map(|v| v as i32))
     .bind(model.last_checked.map(|dt| dt.to_rfc3339()))
+    .bind(&supported_apis_json)
     .bind(&model.canonical_name)
     .bind(model.endpoint_id.to_string())
     .bind(&model.model_id)

--- a/llmlb/src/models/mapping.rs
+++ b/llmlb/src/models/mapping.rs
@@ -382,12 +382,24 @@ impl CanonicalResolution {
     /// 「mapping に登録があるか？」を判定したい場合は [`Self::is_known`] を使用する。
     pub fn canonical_for(&self, model_key: &str) -> String {
         if self.canonical_to_aliases.contains_key(model_key) {
-            model_key.to_string()
-        } else if let Some(canonical) = self.model_to_canonical.get(model_key) {
-            canonical.clone()
-        } else {
-            model_key.to_string()
+            return model_key.to_string();
         }
+        if let Some(canonical) = self.model_to_canonical.get(model_key) {
+            return canonical.clone();
+        }
+        // 量子化サフィックス（:Q4_K_M 等）を除いた base ID で再 lookup する
+        // （ggml-org の GGUF リポジトリのように、量子化バリアントが alias に未登録なケース）。
+        let (base, quant) = split_quantization_suffix(model_key);
+        if quant.is_some() && base != model_key {
+            if self.canonical_to_aliases.contains_key(base) {
+                return base.to_string();
+            }
+            if let Some(canonical) = self.model_to_canonical.get(base) {
+                return canonical.clone();
+            }
+        }
+        // self-canonical fallback
+        model_key.to_string()
     }
 
     /// `model_key` が canonical テーブルに登録されているか。
@@ -428,6 +440,45 @@ pub fn build_canonical_maps<'a>(
             .insert(model_id.to_string(), canonical.to_string());
     }
     res
+}
+
+/// 量子化サフィックス（`:Q4_K_M` `:Q8_0` `:F16` 等）をモデル ID から分離する。
+///
+/// 戻り値は `(base_id, quantization)` のタプル。suffix が量子化タグに該当する場合は
+/// `:` の前後に分割し、そうでなければ元の `model_id` 全体を base として返す
+/// （`qwen3-coder:30b` のような Ollama 形式タグや `gemma3:latest` を誤検出しない）。
+///
+/// G-3 の暫定対応として、ID は当面互換性のため変更せず、量子化情報は新フィールド
+/// `quantization` として API レスポンスに別出しする。
+pub fn split_quantization_suffix(model_id: &str) -> (&str, Option<&str>) {
+    if let Some(idx) = model_id.rfind(':') {
+        let suffix = &model_id[idx + 1..];
+        if is_quantization_tag(suffix) {
+            return (&model_id[..idx], Some(suffix));
+        }
+    }
+    (model_id, None)
+}
+
+/// 与えられた文字列が GGUF / safetensors の量子化タグらしいかを判定する。
+///
+/// 認識する形式:
+/// - `Q[0-9]...`: `Q4_K_M`, `Q5_K_M`, `Q8_0` など（GGUF k-quants/legacy quants）
+/// - `IQ[0-9]...`: `IQ4_XS`, `IQ3_S` など（GGUF imatrix quants）
+/// - 浮動小数点フォーマット: `F16`, `F32`, `BF16`, `FP16`, `FP32`, `F8E4M3FN`, `F8E5M2`
+fn is_quantization_tag(s: &str) -> bool {
+    if matches!(
+        s,
+        "F16" | "F32" | "BF16" | "FP16" | "FP32" | "F8E4M3FN" | "F8E5M2"
+    ) {
+        return true;
+    }
+    let mut chars = s.chars();
+    match chars.next() {
+        Some('Q') => chars.next().is_some_and(|c| c.is_ascii_digit()),
+        Some('I') => chars.next() == Some('Q'),
+        _ => false,
+    }
 }
 
 /// 既知 canonical モデルのコンテキスト長フォールバックテーブル。
@@ -911,6 +962,61 @@ mod tests {
         let res = build_canonical_maps(models.into_iter());
 
         assert_eq!(res.canonical_for("gpt-oss:20b"), "openai/gpt-oss-20b");
+    }
+
+    #[test]
+    fn test_split_quantization_suffix_extracts_quantization_tag() {
+        // GGUF 量子化サフィックス
+        let (base, q) = split_quantization_suffix("ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M");
+        assert_eq!(base, "ggml-org/gemma-4-E4B-it-GGUF");
+        assert_eq!(q, Some("Q4_K_M"));
+
+        // Q5_K_M, Q8_0
+        let (_, q5) = split_quantization_suffix("foo/bar:Q5_K_M");
+        assert_eq!(q5, Some("Q5_K_M"));
+        let (_, q8) = split_quantization_suffix("foo/bar:Q8_0");
+        assert_eq!(q8, Some("Q8_0"));
+
+        // 浮動小数点フォーマット
+        let (_, f16) = split_quantization_suffix("foo/bar:F16");
+        assert_eq!(f16, Some("F16"));
+        let (_, bf16) = split_quantization_suffix("foo/bar:BF16");
+        assert_eq!(bf16, Some("BF16"));
+
+        // imatrix 量子化（IQ*）
+        let (_, iq) = split_quantization_suffix("foo/bar:IQ4_XS");
+        assert_eq!(iq, Some("IQ4_XS"));
+    }
+
+    #[test]
+    fn test_split_quantization_suffix_returns_none_for_non_quantization_tags() {
+        // Ollama タグ（`:30b` `:latest` 等）は量子化ではない
+        let (base, q) = split_quantization_suffix("qwen3-coder:30b");
+        assert_eq!(base, "qwen3-coder:30b");
+        assert_eq!(q, None);
+
+        let (base2, q2) = split_quantization_suffix("gemma3:latest");
+        assert_eq!(base2, "gemma3:latest");
+        assert_eq!(q2, None);
+
+        // コロンなし
+        let (base3, q3) = split_quantization_suffix("openai/gpt-oss-20b");
+        assert_eq!(base3, "openai/gpt-oss-20b");
+        assert_eq!(q3, None);
+    }
+
+    #[test]
+    fn test_canonical_for_falls_back_to_quantization_stripped_lookup() {
+        // base 名が canonical 表に登録されているとき、量子化付き ID も同じ canonical へ解決される
+        let models = vec![("gguf-base", Some("vendor/base"))];
+        let res = build_canonical_maps(models.into_iter());
+
+        // suffix 付き ID は逆引きにないが、suffix 除去後にヒットする
+        assert_eq!(res.canonical_for("gguf-base:Q4_K_M"), "vendor/base");
+        assert_eq!(res.canonical_for("gguf-base:F16"), "vendor/base");
+
+        // 量子化タグでない suffix は self-canonical fallback のまま
+        assert_eq!(res.canonical_for("gguf-base:foo"), "gguf-base:foo");
     }
 
     #[test]

--- a/llmlb/src/models/mapping.rs
+++ b/llmlb/src/models/mapping.rs
@@ -245,8 +245,10 @@ pub static BUILTIN_MAPPINGS: &[ModelMapping] = &[
             },
         ],
     },
+    // GLM-4.7-Flash: HuggingFace 上の現行リポジトリは `zai-org/glm-4.7-flash`（旧 THUDM）。
+    // canonical は実在するリポジトリ ID に合わせ、`THUDM/...` は alias として残す。
     ModelMapping {
-        canonical: "THUDM/glm-4.7-flash",
+        canonical: "zai-org/glm-4.7-flash",
         aliases: &[
             EngineAlias {
                 engine: EndpointType::Ollama,
@@ -258,17 +260,15 @@ pub static BUILTIN_MAPPINGS: &[ModelMapping] = &[
             },
             EngineAlias {
                 engine: EndpointType::LmStudio,
-                name: "zai-org/glm-4.7-flash",
+                name: "THUDM/glm-4.7-flash",
             },
         ],
     },
+    // Gemma 4 (26B-A4B): `:latest` は将来世代の登場で意味がねじれる反パターンのため alias から外す。
+    // 具体タグ `gemma4` のみを Ollama alias として保持。
     ModelMapping {
         canonical: "google/gemma-4-26b-a4b",
         aliases: &[
-            EngineAlias {
-                engine: EndpointType::Ollama,
-                name: "gemma4:latest",
-            },
             EngineAlias {
                 engine: EndpointType::Ollama,
                 name: "gemma4",
@@ -373,15 +373,27 @@ pub struct CanonicalResolution {
 impl CanonicalResolution {
     /// Resolve the canonical name to display for a given model key.
     ///
-    /// If the key itself is a known canonical name (present in
-    /// `canonical_to_aliases`), returns it directly. Otherwise falls back to
-    /// the `model_to_canonical` reverse map.
-    pub fn canonical_for(&self, model_key: &str) -> Option<String> {
+    /// 解決順:
+    /// 1. `model_key` 自体が canonical 名（`canonical_to_aliases` にエントリあり）→ そのまま返す。
+    /// 2. `model_to_canonical` の逆引きで canonical が見つかる → それを返す。
+    /// 3. いずれも該当なし → `model_key` 自身を canonical として返す（self-canonical fallback）。
+    ///
+    /// fallback により `/v1/models` レスポンスで `canonical_name: null` が出ることがなくなる。
+    /// 「mapping に登録があるか？」を判定したい場合は [`Self::is_known`] を使用する。
+    pub fn canonical_for(&self, model_key: &str) -> String {
         if self.canonical_to_aliases.contains_key(model_key) {
-            Some(model_key.to_string())
+            model_key.to_string()
+        } else if let Some(canonical) = self.model_to_canonical.get(model_key) {
+            canonical.clone()
         } else {
-            self.model_to_canonical.get(model_key).cloned()
+            model_key.to_string()
         }
+    }
+
+    /// `model_key` が canonical テーブルに登録されているか。
+    pub fn is_known(&self, model_key: &str) -> bool {
+        self.canonical_to_aliases.contains_key(model_key)
+            || self.model_to_canonical.contains_key(model_key)
     }
 
     /// Sorted aliases for a given model key.
@@ -416,6 +428,53 @@ pub fn build_canonical_maps<'a>(
             .insert(model_id.to_string(), canonical.to_string());
     }
     res
+}
+
+/// 既知 canonical モデルのコンテキスト長フォールバックテーブル。
+///
+/// エンドポイントが `/v1/models` で `max_tokens` を申告しないケース（B-1, G-7）への対策として、
+/// 公開情報から確認できる代表的なモデルの context window をハードコードしている。
+/// エンドポイント申告が優先されるため、このテーブルはあくまで欠損値補填用。
+///
+/// 値の出典: 各モデルの HuggingFace モデルカード／公式リリースノート時点での公称 context length。
+const KNOWN_CONTEXT_LENGTHS: &[(&str, u32)] = &[
+    // OpenAI gpt-oss
+    ("openai/gpt-oss-20b", 131_072),
+    ("openai/gpt-oss-120b", 131_072),
+    // Qwen
+    ("Qwen/Qwen3-Coder-30B-A3B-Instruct", 262_144),
+    ("Qwen/Qwen3.5-35B-A3B", 262_144),
+    ("Qwen/Qwen2.5-14B-Instruct-AWQ", 32_768),
+    // Google Gemma
+    ("google/gemma-3-27b-it", 131_072),
+    ("google/gemma-4-26b-a4b", 131_072),
+    // GLM
+    ("zai-org/glm-4.7-flash", 131_072),
+    // Nvidia Nemotron
+    ("nvidia/nemotron-3-super-120b-a12b", 131_072),
+    ("nvidia/Nemotron-3-Nano", 131_072),
+    // Meta Llama
+    ("meta-llama/Llama-3.3-70B-Instruct", 131_072),
+    // Embeddings
+    ("nomic-ai/nomic-embed-text-v1.5", 8_192),
+];
+
+/// 既知 canonical の context length を返す（未登録なら `None`）。
+pub fn known_max_tokens(canonical: &str) -> Option<u32> {
+    KNOWN_CONTEXT_LENGTHS
+        .iter()
+        .find(|(name, _)| *name == canonical)
+        .map(|(_, len)| *len)
+}
+
+/// `max_tokens` をエンドポイント申告 → known テーブルの順に解決する。
+///
+/// 値の優先順位:
+/// 1. エンドポイントが申告した値（`endpoint_reported`）。
+/// 2. `KNOWN_CONTEXT_LENGTHS` のフォールバック値。
+/// 3. いずれも該当なし → `None`（API レスポンスでは `null` として表現）。
+pub fn resolve_max_tokens(canonical: &str, endpoint_reported: Option<u32>) -> Option<u32> {
+    endpoint_reported.or_else(|| known_max_tokens(canonical))
 }
 
 /// Resolve a canonical ID by matching against any known alias regardless of endpoint type.
@@ -648,8 +707,13 @@ mod tests {
 
     #[test]
     fn test_glm47_mapping() {
+        // canonical は zai-org に統一（HF 上の現行リポジトリ）
         let result = resolve_canonical("zai-org/glm-4.7-flash", &EndpointType::LmStudio);
-        assert_eq!(result, Some("THUDM/glm-4.7-flash"));
+        assert_eq!(result, Some("zai-org/glm-4.7-flash"));
+
+        // 旧 THUDM 名は alias として canonical に解決される
+        let legacy = resolve_canonical("THUDM/glm-4.7-flash", &EndpointType::LmStudio);
+        assert_eq!(legacy, Some("zai-org/glm-4.7-flash"));
     }
 
     #[test]
@@ -712,10 +776,14 @@ mod tests {
     #[test]
     fn test_glm_flash_mapping() {
         let ollama = resolve_canonical("glm-4.7-flash:latest", &EndpointType::Ollama);
-        assert_eq!(ollama, Some("THUDM/glm-4.7-flash"));
+        assert_eq!(ollama, Some("zai-org/glm-4.7-flash"));
 
         let result = resolve_canonical("zai-org/glm-4.7-flash", &EndpointType::LmStudio);
-        assert_eq!(result, Some("THUDM/glm-4.7-flash"));
+        assert_eq!(result, Some("zai-org/glm-4.7-flash"));
+
+        // legacy THUDM/... も alias 経由で canonical に解決される
+        let legacy = resolve_canonical("THUDM/glm-4.7-flash", &EndpointType::LmStudio);
+        assert_eq!(legacy, Some("zai-org/glm-4.7-flash"));
     }
 
     #[test]
@@ -743,11 +811,13 @@ mod tests {
 
     #[test]
     fn test_gemma4_ollama_resolves_to_canonical() {
-        let result = resolve_canonical("gemma4:latest", &EndpointType::Ollama);
-        assert_eq!(result, Some("google/gemma-4-26b-a4b"));
+        // `gemma4:latest` は撤廃済み（将来世代の登場で意味がねじれるため）。
+        let removed = resolve_canonical("gemma4:latest", &EndpointType::Ollama);
+        assert_eq!(removed, None);
 
-        let result2 = resolve_canonical("gemma4", &EndpointType::Ollama);
-        assert_eq!(result2, Some("google/gemma-4-26b-a4b"));
+        // 具体タグ `gemma4` は引き続き alias として解決される。
+        let result = resolve_canonical("gemma4", &EndpointType::Ollama);
+        assert_eq!(result, Some("google/gemma-4-26b-a4b"));
     }
 
     #[test]
@@ -758,8 +828,9 @@ mod tests {
 
     #[test]
     fn test_gemma4_engine_name_resolution() {
+        // `:latest` 撤廃により Ollama 側の優先 alias は具体タグ `gemma4`
         let ollama = resolve_engine_name("google/gemma-4-26b-a4b", &EndpointType::Ollama);
-        assert_eq!(ollama, Some("gemma4:latest"));
+        assert_eq!(ollama, Some("gemma4"));
 
         let lms = resolve_engine_name("google/gemma-4-26b-a4b", &EndpointType::LmStudio);
         assert_eq!(lms, Some("google/gemma-4-26b-a4b"));
@@ -830,7 +901,7 @@ mod tests {
 
         assert_eq!(
             res.canonical_for("openai/gpt-oss-20b"),
-            Some("openai/gpt-oss-20b".to_string())
+            "openai/gpt-oss-20b"
         );
     }
 
@@ -839,18 +910,61 @@ mod tests {
         let models = vec![("gpt-oss:20b", Some("openai/gpt-oss-20b"))];
         let res = build_canonical_maps(models.into_iter());
 
+        assert_eq!(res.canonical_for("gpt-oss:20b"), "openai/gpt-oss-20b");
+    }
+
+    #[test]
+    fn test_known_max_tokens_returns_value_for_known_canonical() {
+        assert_eq!(known_max_tokens("openai/gpt-oss-20b"), Some(131_072));
         assert_eq!(
-            res.canonical_for("gpt-oss:20b"),
-            Some("openai/gpt-oss-20b".to_string())
+            known_max_tokens("Qwen/Qwen3-Coder-30B-A3B-Instruct"),
+            Some(262_144)
+        );
+        assert_eq!(known_max_tokens("zai-org/glm-4.7-flash"), Some(131_072));
+        assert_eq!(
+            known_max_tokens("nomic-ai/nomic-embed-text-v1.5"),
+            Some(8_192)
         );
     }
 
     #[test]
-    fn test_canonical_for_returns_none_for_unknown() {
+    fn test_known_max_tokens_returns_none_for_unknown() {
+        assert_eq!(known_max_tokens("ggml-org/gemma-4-E2B-it-GGUF"), None);
+        assert_eq!(known_max_tokens(""), None);
+    }
+
+    #[test]
+    fn test_resolve_max_tokens_prefers_endpoint_reported() {
+        // endpoint 申告がある場合はそれを採用（既知テーブルより優先）
+        let resolved = resolve_max_tokens("openai/gpt-oss-20b", Some(65_536));
+        assert_eq!(resolved, Some(65_536));
+    }
+
+    #[test]
+    fn test_resolve_max_tokens_falls_back_to_known_table() {
+        // endpoint 申告が無い場合は known テーブルから取得
+        let resolved = resolve_max_tokens("openai/gpt-oss-20b", None);
+        assert_eq!(resolved, Some(131_072));
+    }
+
+    #[test]
+    fn test_resolve_max_tokens_returns_none_for_unknown() {
+        // どちらにも無ければ None（レスポンスでは null）
+        let resolved = resolve_max_tokens("totally-unknown-model", None);
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn test_canonical_for_returns_self_for_unknown() {
+        // self-canonical fallback: mapping 未登録のモデルは id 自身を canonical とする
+        // （`/v1/models` レスポンスで canonical_name: null を出さない方針）
         let models = vec![("gpt-oss:20b", Some("openai/gpt-oss-20b"))];
         let res = build_canonical_maps(models.into_iter());
 
-        assert_eq!(res.canonical_for("unknown-model"), None);
+        assert_eq!(res.canonical_for("unknown-model"), "unknown-model");
+        assert!(!res.is_known("unknown-model"));
+        assert!(res.is_known("openai/gpt-oss-20b"));
+        assert!(res.is_known("gpt-oss:20b"));
     }
 
     #[test]

--- a/llmlb/src/registry/endpoints.rs
+++ b/llmlb/src/registry/endpoints.rs
@@ -10,7 +10,11 @@ use sqlx::SqlitePool;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
+
+/// 単一エンドポイントが「異常な数」のモデルを申告したと判定する閾値。
+/// この値を超えたら `warn!()` ログで運用者に通知する（実態を持たない誤申告の早期検知用）。
+const SUSPICIOUS_MODEL_COUNT_THRESHOLD: usize = 50;
 use uuid::Uuid;
 
 fn model_lookup_keys(model_id: &str) -> Vec<String> {
@@ -537,6 +541,17 @@ impl EndpointRegistry {
             total = models.len(),
             "Synced endpoint models"
         );
+
+        // 単一エンドポイントが過剰なモデル数を申告した場合に警告（誤申告/設定ミスの早期検知）。
+        // 例: カタログ集約サーバが実体なしの全モデルを `/v1/models` で返してしまうケース。
+        if models.len() > SUSPICIOUS_MODEL_COUNT_THRESHOLD {
+            warn!(
+                endpoint_id = %endpoint_id,
+                model_count = models.len(),
+                threshold = SUSPICIOUS_MODEL_COUNT_THRESHOLD,
+                "Endpoint reported suspiciously many models. Verify the endpoint is not aggregating models it cannot serve (see CLAUDE.md C-1/C-2 notes)"
+            );
+        }
 
         Ok(SyncResult {
             added: added.len(),
@@ -1789,6 +1804,42 @@ mod tests {
         // モデルマッピングが正しく再構築されている
         let found = registry.find_by_model("refresh-model").await;
         assert_eq!(found.len(), 1);
+    }
+
+    /// C-defensive: 単一エンドポイントが 50 件超を申告しても sync_models が成功すること
+    /// （warn ログが出力される動作は tracing 出力検証の範囲外。本テストは regression 用）
+    #[tokio::test]
+    async fn test_sync_models_handles_suspiciously_large_model_list() {
+        let _lock = TEST_LOCK.lock().await;
+        let pool = setup_test_db().await;
+        let registry = EndpointRegistry::new(pool).await.unwrap();
+
+        let mut ep = Endpoint::new(
+            "ManyModelsEndpoint".to_string(),
+            "http://localhost:9027".to_string(),
+            EndpointType::Xllm,
+        );
+        ep.status = EndpointStatus::Online;
+        let ep_id = ep.id;
+        registry.add(ep).await.unwrap();
+
+        // 閾値（50）を確実に超える 60 モデルを申告
+        let models: Vec<EndpointModel> = (0..60)
+            .map(|i| EndpointModel {
+                endpoint_id: ep_id,
+                model_id: format!("test-model-{:03}", i),
+                capabilities: None,
+                max_tokens: None,
+                last_checked: None,
+                supported_apis: vec![SupportedAPI::ChatCompletions],
+                canonical_name: None,
+            })
+            .collect();
+
+        let result = registry.sync_models(ep_id, models).await.unwrap();
+        assert_eq!(result.added, 60);
+        assert_eq!(result.removed, 0);
+        assert_eq!(result.total, 60);
     }
 
     // ===== SyncResult テスト =====


### PR DESCRIPTION
## Summary

`http://192.168.100.166:32768/v1/models` のレスポンスを精査し、SPEC #575 US-001「OpenAI互換API完全準拠」に対する5項目の不整合を補正します。

- **A-1 (高)**: embedding capability を持つモデル (`nomic-ai/nomic-embed-text-v1.5` 等) の `supported_apis` に `embeddings` が含まれない問題を修正。`ModelInfo.capabilities` から `SupportedAPI` を導出するように変更。
- **A-2 (中)**: `created` の `0` ハードコードを撤廃。`ModelInfo.last_modified` の Unix epoch を採用、無い場合は観測時刻にフォールバック。
- **A-3 (低)**: `supported_apis` の配列順序を `as_str()` 昇順で決定論化（HashSet 由来の非決定性を排除）。
- **A-4 (中)**: endpoint-only 分岐の `ready: true` 固定を撤廃し、`available_set` 判定で統一。
- **A-5 (低)**: `owned_by` を `id` の組織プレフィックス由来に統一（`"load balancer"` / `"endpoint"` の分裂を解消）。

合わせて `list_models` 内の到達不能な `endpoint_model_apis` 再走査ループを削除し、`get_model` (`/v1/models/:id`) との重複ロジックを `build_supported_apis` / `owned_by_from_id` ヘルパーに集約しました。

スコープ外（別 PR / 別 SPEC で対応）:

- B 群（メタデータ品質、`max_tokens` フォールバック、canonical テーブル整備）
- C 群（運用構成異常: 単一エンドポイントが13/14モデルを申告等）
- G 群（Gemma 4 系の canonical 集約・量子化サフィックス命名規則）

関連: #575 US-001（コメント [#issuecomment-4324494633](https://github.com/akiojin/llmlb/issues/575#issuecomment-4324494633) で詳細記録）

## Test plan

- [x] `cargo test` 全パス（lib 2,808 + contract 243 + integration 151 ほか、計 3,470 件 OK）
- [x] `cargo clippy --all-targets -- -D warnings` 0 warnings
- [x] `cargo fmt --check` 合格
- [x] `markdownlint-cli2 "**/*.md" ...` 0 errors（410 ファイル検査）
- [x] `scripts/checks/check-commits.sh --from origin/develop --to HEAD` 合格
- [x] TDD RED → GREEN サイクル: 4 件の失敗テストを追加 → 実装で全件 GREEN 化
  - `list_models_embedding_capability_emits_embeddings_api`
  - `list_models_registered_created_reflects_last_modified`
  - `list_models_supported_apis_are_sorted`
  - `list_models_owned_by_uses_id_org_prefix`
- [ ] 本番側で `192.168.100.166:32768/v1/models` 再取得し、A-1〜A-5 の解消を確認（マージ後）
