### PR TITLE
test(e2e): harden real local runtime timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test-hooks:
 # Automatically starts the server via playwright.config.ts webServer.
 # Set SKIP_SERVER=1 to use an already-running server.
 e2e-playwright:
-	@cd llmlb/tests/e2e-playwright && pnpm exec playwright test --project=chromium || \
+	@cd llmlb/tests/e2e-playwright && pnpm exec playwright test --project=chromium --grep-invert @real-runtimes || \
 		(echo "⚠️  Some Playwright E2E tests failed. Review the report above." && exit 0)
 
 # Playwright E2E screenshot capture (headed mode)

--- a/llmlb/tests/e2e-playwright/helpers/real-local-runtime.ts
+++ b/llmlb/tests/e2e-playwright/helpers/real-local-runtime.ts
@@ -3,7 +3,6 @@ import { spawnSync } from 'node:child_process'
 import { DashboardPage } from '../pages/dashboard.page'
 import {
   deleteApiKey,
-  deleteEndpointsByBaseUrl,
   deleteEndpointsByName,
   listApiKeys,
   listEndpoints,
@@ -15,6 +14,25 @@ export const DASHBOARD_ORIGIN = new URL(API_BASE).origin
 export const OLLAMA_BASE = 'http://127.0.0.1:11434'
 export const LM_STUDIO_BASE = 'http://127.0.0.1:1234'
 const DEBUG_AUTH_HEADERS = { Authorization: 'Bearer sk_debug' }
+
+function positiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+export const REAL_LOCAL_RUNTIME_JIT_TIMEOUT_SECS = positiveIntEnv(
+  'LLMLB_E2E_REAL_LOCAL_JIT_TIMEOUT_SECS',
+  600
+)
+export const REAL_LOCAL_RUNTIME_JIT_TIMEOUT_MS = REAL_LOCAL_RUNTIME_JIT_TIMEOUT_SECS * 1000
+export const REAL_LOCAL_RUNTIME_READINESS_TIMEOUT_MS =
+  positiveIntEnv('LLMLB_E2E_REAL_LOCAL_READINESS_TIMEOUT_SECS', 300) * 1000
+export const REAL_LOCAL_RUNTIME_FAILURE_TIMEOUT_MS =
+  positiveIntEnv('LLMLB_E2E_REAL_LOCAL_FAILURE_TIMEOUT_SECS', 180) * 1000
+export const REAL_LOCAL_RUNTIME_SAVE_TIMEOUT_MS =
+  positiveIntEnv('LLMLB_E2E_REAL_LOCAL_SAVE_TIMEOUT_SECS', 30) * 1000
 
 export type OllamaTagsResponse = {
   models?: Array<{ name?: string }>
@@ -480,7 +498,7 @@ export async function waitForEndpointStatus(
         const endpoint = (await listEndpoints(request)).find((entry) => entry.name === endpointName)
         return expected.includes(endpoint?.status ?? '')
       },
-      { timeout: 120000, intervals: [1000, 2000, 5000] }
+      { timeout: REAL_LOCAL_RUNTIME_READINESS_TIMEOUT_MS, intervals: [1000, 2000, 5000] }
     )
     .toBeTruthy()
 }
@@ -498,7 +516,7 @@ export async function waitForEndpointTypeAndStatus(
         if (!endpoint) return 'missing'
         return `${endpoint.status}|${endpoint.endpoint_type ?? ''}`
       },
-      { timeout: 120000, intervals: [1000, 2000, 5000] }
+      { timeout: REAL_LOCAL_RUNTIME_READINESS_TIMEOUT_MS, intervals: [1000, 2000, 5000] }
     )
     .toBe(`online|${endpointType}`)
 }
@@ -561,7 +579,7 @@ export async function prepareEndpointViaUi(
     typeLabel: 'Ollama' | 'LM Studio'
   }
 ) {
-  await deleteEndpointsByBaseUrl(request, options.baseUrl)
+  await deleteEndpointsByName(request, options.endpointName)
   let row = await registerEndpointViaUi(page, options.endpointName, options.baseUrl)
   await waitForEndpointRegistered(request, options.endpointName)
   await row.locator('button[title="Test Connection"]').click()
@@ -575,7 +593,7 @@ export async function prepareEndpointViaUi(
     .poll(async () => {
       const endpoint = await getEndpointByName(request, options.endpointName)
       return endpoint?.model_count ?? 0
-    }, { timeout: 120000, intervals: [1000, 2000, 5000] })
+    }, { timeout: REAL_LOCAL_RUNTIME_READINESS_TIMEOUT_MS, intervals: [1000, 2000, 5000] })
     .toBeGreaterThan(0)
 
   const endpoint = await getEndpointByName(request, options.endpointName)
@@ -606,7 +624,7 @@ export async function waitForModelVisibleInDetails(
   const detailsDialog = page.getByRole('dialog').filter({ hasText: endpointName })
   await expect(detailsDialog).toBeVisible({ timeout: 20000 })
   await expect(detailsDialog.getByText(expectedModel, { exact: true })).toBeVisible({
-    timeout: 120000,
+    timeout: REAL_LOCAL_RUNTIME_READINESS_TIMEOUT_MS,
   })
   await page.keyboard.press('Escape')
   await expect(detailsDialog).toBeHidden({ timeout: 20000 })
@@ -634,7 +652,7 @@ export async function waitForApiModelVisible(
         resolvedModelId = match?.id?.trim() ?? ''
         return resolvedModelId
       },
-      { timeout: 120000, intervals: [1000, 2000, 5000] }
+      { timeout: REAL_LOCAL_RUNTIME_READINESS_TIMEOUT_MS, intervals: [1000, 2000, 5000] }
     )
     .not.toBe('')
 
@@ -695,7 +713,7 @@ export async function resolveApiModelIdForRuntimeModel(
         resolvedModelId = match?.id?.trim() ?? ''
         return resolvedModelId
       },
-      { timeout: 120000, intervals: [1000, 2000, 5000] }
+      { timeout: REAL_LOCAL_RUNTIME_READINESS_TIMEOUT_MS, intervals: [1000, 2000, 5000] }
     )
     .not.toBe('')
 
@@ -804,7 +822,7 @@ export async function expectChatCompletion(
         'Content-Type': 'application/json',
         Authorization: `Bearer ${apiKey}`,
       },
-      timeout: options?.timeout ?? 120000,
+      timeout: options?.timeout ?? REAL_LOCAL_RUNTIME_JIT_TIMEOUT_MS,
     })
     if (!response.ok()) {
       const bodyText = await response.text()
@@ -866,7 +884,7 @@ export async function expectChatCompletionError(
         'Content-Type': 'application/json',
         Authorization: `Bearer ${apiKey}`,
       },
-      timeout: options.timeout ?? 120000,
+      timeout: options.timeout ?? REAL_LOCAL_RUNTIME_FAILURE_TIMEOUT_MS,
     })
     expect(response.status()).toBe(options.status)
 
@@ -904,7 +922,7 @@ export async function expectEmbeddings(
         'Content-Type': 'application/json',
         Authorization: `Bearer ${apiKey}`,
       },
-      timeout: 120000,
+      timeout: REAL_LOCAL_RUNTIME_JIT_TIMEOUT_MS,
     })
     expect(response.ok()).toBeTruthy()
 
@@ -945,7 +963,7 @@ export async function postStreamingChatCompletion(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${apiKey}`,
     },
-    timeout: 300000,
+    timeout: REAL_LOCAL_RUNTIME_JIT_TIMEOUT_MS,
   })
   expect(response.ok()).toBeTruthy()
   const text = await response.text()
@@ -982,7 +1000,9 @@ export async function sendPlaygroundMessage(page: Page, message: string) {
 
 export async function waitForAssistantBubbleCount(page: Page, expectedCount: number) {
   const assistantIcons = page.locator('svg.lucide-bot')
-  await expect(assistantIcons).toHaveCount(expectedCount, { timeout: 120000 })
+  await expect(assistantIcons).toHaveCount(expectedCount, {
+    timeout: REAL_LOCAL_RUNTIME_JIT_TIMEOUT_MS,
+  })
 }
 
 export async function waitForAssistantText(page: Page) {
@@ -998,7 +1018,7 @@ export async function waitForAssistantText(page: Page) {
         return messages.map((message) => message.trim()).filter((message) => message.length > 0)
           .length
       },
-      { timeout: 120000, intervals: [1000, 2000, 5000] }
+      { timeout: REAL_LOCAL_RUNTIME_JIT_TIMEOUT_MS, intervals: [1000, 2000, 5000] }
     )
     .toBeGreaterThan(0)
 }

--- a/llmlb/tests/e2e-playwright/package.json
+++ b/llmlb/tests/e2e-playwright/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "description": "Playwright E2E tests for LLM Router Dashboard and Playground",
   "scripts": {
-    "test": "playwright test",
-    "test:headed": "playwright test --headed",
-    "test:debug": "playwright test --debug",
-    "test:ui": "playwright test --ui",
-    "test:dashboard": "playwright test --grep @dashboard",
-    "test:playground": "playwright test --grep @playground",
+    "test": "playwright test --grep-invert @real-runtimes",
+    "test:headed": "playwright test --headed --grep-invert @real-runtimes",
+    "test:debug": "playwright test --debug --grep-invert @real-runtimes",
+    "test:ui": "playwright test --ui --grep-invert @real-runtimes",
+    "test:dashboard": "playwright test --grep @dashboard --grep-invert @real-runtimes",
+    "test:playground": "playwright test --grep @playground --grep-invert @real-runtimes",
     "test:real-local": "playwright test specs/dashboard/real-dashboard-display.spec.ts specs/workflows/real-local-runtimes.spec.ts specs/workflows/real-local-playground-ui.spec.ts specs/workflows/real-local-endpoint-management.spec.ts specs/workflows/real-local-streaming-failure.spec.ts specs/workflows/real-local-supported-models.spec.ts specs/workflows/real-local-ollama-cold-start.spec.ts --workers 1",
     "test:real-local:headed": "playwright test specs/dashboard/real-dashboard-display.spec.ts specs/workflows/real-local-runtimes.spec.ts specs/workflows/real-local-playground-ui.spec.ts specs/workflows/real-local-endpoint-management.spec.ts specs/workflows/real-local-streaming-failure.spec.ts specs/workflows/real-local-supported-models.spec.ts specs/workflows/real-local-ollama-cold-start.spec.ts --workers 1 --headed",
     "report": "playwright show-report reports/html"

--- a/llmlb/tests/e2e-playwright/specs/dashboard/real-dashboard-display.spec.ts
+++ b/llmlb/tests/e2e-playwright/specs/dashboard/real-dashboard-display.spec.ts
@@ -11,6 +11,8 @@ import {
   openEndpointDetails,
   prepareEndpointViaUi,
   probeLocalRuntimes,
+  REAL_LOCAL_RUNTIME_FAILURE_TIMEOUT_MS,
+  REAL_LOCAL_RUNTIME_SAVE_TIMEOUT_MS,
   RuntimeSelection,
   searchEndpointRow,
   selectEndpointPlaygroundModel,
@@ -126,7 +128,7 @@ test.describe('Real Dashboard Display @dashboard @real-runtimes', () => {
     page,
     request,
   }) => {
-    test.setTimeout(10 * 60_000)
+    test.setTimeout(20 * 60_000)
     test.skip(!runtimeSelection, skipReason)
     test.skip(!coldStartModel, 'No installed Ollama model reproduced a cold-start timeout')
     const model = coldStartModel
@@ -149,7 +151,7 @@ test.describe('Real Dashboard Display @dashboard @real-runtimes', () => {
     await detailsDialog.locator('#inferenceTimeout').fill('1')
     await detailsDialog.getByRole('button', { name: 'Save' }).click()
     await expect(page.getByText('Update Complete', { exact: true }).first()).toBeVisible({
-      timeout: 10000,
+      timeout: REAL_LOCAL_RUNTIME_SAVE_TIMEOUT_MS,
     })
     await detailsDialog.getByRole('button', { name: 'Close', exact: true }).first().click()
 
@@ -158,9 +160,11 @@ test.describe('Real Dashboard Display @dashboard @real-runtimes', () => {
     await selectEndpointPlaygroundModel(page, model)
     await sendPlaygroundMessage(page, 'Reply with OK only.')
     await expect(page.getByText('Failed to send message', { exact: true }).first()).toBeVisible({
-      timeout: 180000,
+      timeout: REAL_LOCAL_RUNTIME_FAILURE_TIMEOUT_MS,
     })
-    await expect(page.getByText(/still loading/i).first()).toBeVisible({ timeout: 180000 })
+    await expect(page.getByText(/still loading/i).first()).toBeVisible({
+      timeout: REAL_LOCAL_RUNTIME_FAILURE_TIMEOUT_MS,
+    })
 
     await expect
       .poll(

--- a/llmlb/tests/e2e-playwright/specs/workflows/real-local-endpoint-management.spec.ts
+++ b/llmlb/tests/e2e-playwright/specs/workflows/real-local-endpoint-management.spec.ts
@@ -7,6 +7,7 @@ import {
   openEndpointDetails,
   prepareEndpointViaUi,
   probeLocalRuntimes,
+  REAL_LOCAL_RUNTIME_SAVE_TIMEOUT_MS,
   RuntimeSelection,
   searchEndpointRow,
   waitForEndpointTypeAndStatus,
@@ -57,7 +58,7 @@ test.describe('Real Local Endpoint Management @workflows @dashboard @real-runtim
     await detailsDialog.locator('#notes').fill(notes)
     await detailsDialog.getByRole('button', { name: 'Save' }).click()
     await expect(page.getByText('Update Complete', { exact: true }).first()).toBeVisible({
-      timeout: 10000,
+      timeout: REAL_LOCAL_RUNTIME_SAVE_TIMEOUT_MS,
     })
     await detailsDialog.getByRole('button', { name: 'Close', exact: true }).first().click()
     await expect(detailsDialog).toBeHidden({ timeout: 10000 })

--- a/llmlb/tests/e2e-playwright/specs/workflows/real-local-ollama-cold-start.spec.ts
+++ b/llmlb/tests/e2e-playwright/specs/workflows/real-local-ollama-cold-start.spec.ts
@@ -14,6 +14,10 @@ import {
   openDashboard,
   openEndpointDetails,
   prepareEndpointViaUi,
+  REAL_LOCAL_RUNTIME_FAILURE_TIMEOUT_MS,
+  REAL_LOCAL_RUNTIME_JIT_TIMEOUT_MS,
+  REAL_LOCAL_RUNTIME_JIT_TIMEOUT_SECS,
+  REAL_LOCAL_RUNTIME_SAVE_TIMEOUT_MS,
   retestEndpointConnection,
   resolveApiModelIdForRuntimeModel,
   selectEndpointPlaygroundModel,
@@ -55,7 +59,7 @@ test.describe('Real Local Ollama Cold Start @workflows @dashboard @real-runtimes
   })
 
   test('cold-start requests honor endpoint inference timeout', async ({ page, request }) => {
-    test.setTimeout(20 * 60_000)
+    test.setTimeout(30 * 60_000)
     test.skip(!coldStartModel, skipReason)
     const model = coldStartModel
     if (!model) return
@@ -81,7 +85,7 @@ test.describe('Real Local Ollama Cold Start @workflows @dashboard @real-runtimes
     await detailsDialog.locator('#inferenceTimeout').fill('1')
     await detailsDialog.getByRole('button', { name: 'Save' }).click()
     await expect(page.getByText('Update Complete', { exact: true }).first()).toBeVisible({
-      timeout: 10000,
+      timeout: REAL_LOCAL_RUNTIME_SAVE_TIMEOUT_MS,
     })
     await detailsDialog.getByRole('button', { name: 'Close', exact: true }).first().click()
     await expect(detailsDialog).toBeHidden({ timeout: 10000 })
@@ -98,9 +102,11 @@ test.describe('Real Local Ollama Cold Start @workflows @dashboard @real-runtimes
     await selectEndpointPlaygroundModel(page, model)
     await sendPlaygroundMessage(page, 'Reply with OK only.')
     await expect(page.getByText('Failed to send message', { exact: true }).first()).toBeVisible({
-      timeout: 180000,
+      timeout: REAL_LOCAL_RUNTIME_FAILURE_TIMEOUT_MS,
     })
-    await expect(page.getByText(/still loading/i).first()).toBeVisible({ timeout: 180000 })
+    await expect(page.getByText(/still loading/i).first()).toBeVisible({
+      timeout: REAL_LOCAL_RUNTIME_FAILURE_TIMEOUT_MS,
+    })
     await retestEndpointConnection(request, endpoint.id, endpointName, 'ollama')
 
     const apiKey = await createApiKeyWithPermissions(request, apiKeyName, [
@@ -125,7 +131,7 @@ test.describe('Real Local Ollama Cold Start @workflows @dashboard @real-runtimes
         status: 504,
         errorType: 'model_loading',
         errorMessageIncludes: 'still loading',
-        timeout: 180000,
+        timeout: REAL_LOCAL_RUNTIME_FAILURE_TIMEOUT_MS,
         maxTokens: 4,
       }
     )
@@ -133,10 +139,10 @@ test.describe('Real Local Ollama Cold Start @workflows @dashboard @real-runtimes
 
     await openDashboard(page)
     detailsDialog = await openEndpointDetails(page, endpointName)
-    await detailsDialog.locator('#inferenceTimeout').fill('300')
+    await detailsDialog.locator('#inferenceTimeout').fill(String(REAL_LOCAL_RUNTIME_JIT_TIMEOUT_SECS))
     await detailsDialog.getByRole('button', { name: 'Save' }).click()
     await expect(page.getByText('Update Complete', { exact: true }).first()).toBeVisible({
-      timeout: 10000,
+      timeout: REAL_LOCAL_RUNTIME_SAVE_TIMEOUT_MS,
     })
     await detailsDialog.getByRole('button', { name: 'Close', exact: true }).first().click()
     await expect(detailsDialog).toBeHidden({ timeout: 10000 })
@@ -146,12 +152,12 @@ test.describe('Real Local Ollama Cold Start @workflows @dashboard @real-runtimes
         timeout: 30000,
         intervals: [500, 1000, 2000],
       })
-      .toBe(300)
+      .toBe(REAL_LOCAL_RUNTIME_JIT_TIMEOUT_SECS)
 
     await retestEndpointConnection(request, endpoint.id, endpointName, 'ollama')
     await ensureOllamaModelUnloaded(request, model)
     await expectChatCompletion(request, apiKey.key, apiModelId, 'Reply with OK only.', {
-      timeout: 300000,
+      timeout: REAL_LOCAL_RUNTIME_JIT_TIMEOUT_MS,
       maxTokens: 4,
     })
   })

--- a/llmlb/tests/e2e-playwright/specs/workflows/real-local-playground-ui.spec.ts
+++ b/llmlb/tests/e2e-playwright/specs/workflows/real-local-playground-ui.spec.ts
@@ -48,7 +48,7 @@ test.describe('Real Local Playground UI @workflows @playground @real-runtimes', 
   })
 
   test('exercise endpoint playground for Ollama and LM Studio', async ({ page, request }) => {
-    test.setTimeout(20 * 60_000)
+    test.setTimeout(30 * 60_000)
     test.skip(!runtimeSelection, skipReason)
     const selection = runtimeSelection
     if (!selection) return

--- a/llmlb/tests/e2e-playwright/specs/workflows/real-local-runtimes.spec.ts
+++ b/llmlb/tests/e2e-playwright/specs/workflows/real-local-runtimes.spec.ts
@@ -6,6 +6,10 @@ import {
   listApiKeys,
   listEndpoints,
 } from '../../helpers/api-helpers'
+import {
+  REAL_LOCAL_RUNTIME_JIT_TIMEOUT_MS,
+  REAL_LOCAL_RUNTIME_READINESS_TIMEOUT_MS,
+} from '../../helpers/real-local-runtime'
 
 const API_BASE = process.env.BASE_URL || 'http://127.0.0.1:32768'
 const DASHBOARD_ORIGIN = new URL(API_BASE).origin
@@ -139,7 +143,15 @@ async function registerEndpointViaUi(page: Page, endpointName: string, baseUrl: 
   await page.getByRole('button', { name: 'Add Endpoint' }).click()
   await page.fill('#endpoint-name', endpointName)
   await page.fill('#endpoint-url', baseUrl)
+  const createResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/endpoints') &&
+      response.request().method() === 'POST' &&
+      response.status() >= 200 &&
+      response.status() < 300
+  )
   await page.getByRole('button', { name: 'Create Endpoint' }).click()
+  await createResponse
   return searchEndpointRow(page, endpointName)
 }
 
@@ -156,7 +168,7 @@ async function waitForEndpointTypeAndStatus(
         if (!endpoint) return 'missing'
         return `${endpoint.status}|${endpoint.endpoint_type ?? ''}`
       },
-      { timeout: 120000, intervals: [1000, 2000, 5000] }
+      { timeout: REAL_LOCAL_RUNTIME_READINESS_TIMEOUT_MS, intervals: [1000, 2000, 5000] }
     )
     .toBe(`online|${endpointType}`)
 }
@@ -170,7 +182,9 @@ async function waitForModelVisibleInDetails(
   await row.locator('button[title="Details"]').click()
   const detailsDialog = page.getByRole('dialog').filter({ hasText: endpointName })
   await expect(detailsDialog).toBeVisible({ timeout: 20000 })
-  await expect(detailsDialog.getByText(expectedModel)).toBeVisible({ timeout: 120000 })
+  await expect(detailsDialog.getByText(expectedModel)).toBeVisible({
+    timeout: REAL_LOCAL_RUNTIME_READINESS_TIMEOUT_MS,
+  })
   await page.keyboard.press('Escape')
   await expect(detailsDialog).toBeHidden({ timeout: 20000 })
 }
@@ -201,7 +215,7 @@ async function waitForApiModelVisible(
         resolvedModelId = match?.id?.trim() ?? ''
         return resolvedModelId
       },
-      { timeout: 120000, intervals: [1000, 2000, 5000] }
+      { timeout: REAL_LOCAL_RUNTIME_READINESS_TIMEOUT_MS, intervals: [1000, 2000, 5000] }
     )
     .not.toBe('')
 
@@ -278,7 +292,7 @@ async function expectChatCompletion(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${apiKey}`,
     },
-    timeout: 300000,
+    timeout: REAL_LOCAL_RUNTIME_JIT_TIMEOUT_MS,
   })
   expect(response.ok()).toBeTruthy()
 
@@ -347,7 +361,7 @@ test.describe('Real Local Runtimes @workflows @real-runtimes', () => {
     page,
     request,
   }) => {
-    test.setTimeout(15 * 60_000)
+    test.setTimeout(30 * 60_000)
     test.skip(!runtimeSelection, skipReason)
     const selection = runtimeSelection
     if (!selection) return


### PR DESCRIPTION
## Summary
- Harden real local runtime E2E tests so local Ollama / LM Studio JIT loading no longer trips short test timeouts.
- Keep normal Playwright gates aligned with CI by excluding `@real-runtimes`; real runtime coverage remains available through `test:real-local` with one worker.

## Context
- Local failures were caused by JIT model loading exceeding the old 120s/300s waits.
- Running real runtime specs through the broad Playwright suite can also make tests interfere with each other because they share local endpoint base URLs and model processes.

## Changes
- Added configurable real runtime timeout constants, defaulting JIT inference waits to 600 seconds and readiness waits to 300 seconds.
- Updated cold-start, playground, endpoint management, and duplicate real runtime helpers to use the shared waits.
- Stopped shared endpoint setup from deleting every endpoint with the same base URL, avoiding cross-spec cleanup interference.
- Updated package scripts and Makefile E2E gate to exclude `@real-runtimes` by default.

## Testing
- `git diff --check`
- `pnpm --dir llmlb/tests/e2e-playwright exec playwright test --list --project=chromium --grep @real-runtimes --reporter=list`
- `pnpm --dir llmlb/tests/e2e-playwright exec playwright test --list --project=chromium --grep-invert @real-runtimes --reporter=list`
- `pnpm --dir llmlb/tests/e2e-playwright exec playwright test specs/workflows/real-local-runtimes.spec.ts --workers 1 --reporter=list` (1 passed)
- `pnpm --dir llmlb/tests/e2e-playwright exec playwright test specs/workflows/real-local-ollama-cold-start.spec.ts --workers 1 --reporter=list` (1 passed)
- `pnpm --dir llmlb/tests/e2e-playwright exec playwright test --project=chromium --grep-invert @real-runtimes --reporter=list` (167 passed / 14 skipped / 1 flaky, retry passed)
- pre-push `make quality-checks` completed and push succeeded; Playwright gate finished with 165 passed / 16 skipped / 1 flaky, retry passed.

## Risk / Impact
- Affects only Playwright E2E scripts/spec helpers and the local Makefile E2E target.
- Longer waits apply only to real local runtime specs; normal E2E is not slowed by JIT waits.

## Deployment
- None.

## Screenshots
- Not applicable.

## Related Issues / Links
- PR #656 follow-up.

## Checklist
- [x] Tests added/updated
- [x] Lint/format checked
- [x] Docs updated
- [x] Migration/backfill plan included (not needed)
- [x] Monitoring/alerts updated (not needed)

## Notes
- Existing local warnings remain: Windows incremental compilation sometimes reports access denied while final commands still pass.
- Existing flaky test observed: `specs/dashboard/screen-navigation.spec.ts` NAV-08 times out once during cleanup, then passes on retry.