### PR TITLE
chore(release): v5.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [5.10.1](https://github.com/akiojin/llmlb/compare/v5.10.0...v5.10.1) (2026-06-03)
+
+### Chore
+
+- Cargo 依存パッケージ更新（dependabot cargo group, 6件）: tower-http 0.6.10→0.6.11 / sysinfo 0.39.1→0.39.2 / tar 0.4.45→0.4.46 (#662)、serde_json 1.0.149→1.0.150 / reqwest 0.13.3→0.13.4 / rpassword 7.5.2→7.5.3 (#665)
+
 ## [5.10.0](https://github.com/akiojin/llmlb/compare/v5.9.0...v5.10.0) (2026-05-20)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4789,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.1"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4deba334e1190ba7cb498327affa11e5ece10d26a30ab2f27fcf09504b8d8b6"
+checksum = "14311e7e9a03114cd4b65eedd54e8fed2945e17f08586ae97ef53bc0669f9581"
 dependencies = [
  "libc",
  "memchr",
@@ -4817,9 +4817,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -5188,9 +5188,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llmlb"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,9 +3850,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -3917,9 +3917,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.2"
+version = "7.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+checksum = "835a57a69104632d64deb0df2e09a69945cd7a6eab4070fc9b1d7e50cf6c3edc"
 dependencies = [
  "libc",
  "rtoolbox",
@@ -4236,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["llmlb"]
 resolver = "2"
 
 [workspace.package]
-version = "5.10.0"
+version = "5.10.1"
 edition = "2021"
 authors = ["LLM Router Contributors"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- リリース **v5.10.1**（dependabot による Cargo 依存パッケージ更新のメンテナンスリリース）
- v5.10.0 以降の変更は依存更新のみで、ソースコードの機能変更はありません。

## Release Notes

### Chore

- Cargo 依存パッケージ更新（dependabot cargo group, 6件）:
  - tower-http 0.6.10→0.6.11 / sysinfo 0.39.1→0.39.2 / tar 0.4.45→0.4.46 (#662)
  - serde_json 1.0.149→1.0.150 / reqwest 0.13.3→0.13.4 / rpassword 7.5.2→7.5.3 (#665)

## Closing Issues

なし（dependabot の依存更新のみ。クローズ対象の Issue はありません）

## Release Trigger / マージ手順

- このPRを **マージコミット**（squash ではなく）でマージしてください。
- main への push で `release.yml` が発火し、タグ `v5.10.1` 作成 → GitHub Release（CHANGELOG の `## [5.10.1]` から抽出）→ `publish.yml` がバイナリを添付します。
- PRタイトルに `chore(release):` を含めているため、マージコミットメッセージがトリガー条件 `contains(head_commit.message, 'chore(release):')` を満たします。

## ローカル検証メモ

- `cargo fmt --check` ✓ / `cargo check --workspace` ✓ / `markdownlint CHANGELOG.md` 0 error ✓
- 既知のローカル限定の非ブロッカー（本リリース変更とは無関係・CI対象外）:
  - clippy `collapsible_match` は `llmlb/src/gui/tray.rs`（`#![cfg(target_os = windows/macos)]`）の macOS 限定コードで、Linux CI ではコンパイル対象外。
  - markdownlint MD037 は `.claude/skills/gwt-verify/SKILL.md`（gitignore 済みのローカルプラグインファイル）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バージョン 5.10.1 リリースノート

* **Chore**
  * バージョンを 5.10.1 へ更新しました
  * 複数の依存パッケージを最新版に更新しました（tower-http、sysinfo、tar、serde_json、reqwest、rpassword）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->