### PR TITLE
chore(deps): resolve RustSec advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3576,9 +3576,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -5730,9 +5730,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
  "quick-xml",

--- a/llmlb/tests/contract/endpoints_contract_extended_test.rs
+++ b/llmlb/tests/contract/endpoints_contract_extended_test.rs
@@ -1188,12 +1188,7 @@ async fn test_delete_endpoint_invalid_api_key() {
 #[tokio::test]
 #[serial]
 async fn test_viewer_cannot_create_endpoint() {
-    let TestApp {
-        app,
-        db_pool,
-        admin_key: _,
-        ..
-    } = build_app().await;
+    let TestApp { app, db_pool, .. } = build_app().await;
 
     // Viewerユーザーを作成
     let password_hash = llmlb::auth::password::hash_password("viewer123").unwrap();


### PR DESCRIPTION
## Summary

- `crossbeam-epoch` と `quick-xml` を修正版へ更新し、既知の RustSec advisory 3 件を解消します。
- `.cargo/audit.toml` に例外を追加せず、全 PR を阻害していた `cargo audit` failure を恒久解消します。
- Rust 1.97 の CI で新たに有効化された Clippy lint を、既存契約テストの冗長な構造体パターンから除去します。

## Changes

- `Cargo.lock`: `crossbeam-epoch` を 0.9.18 から 0.9.20 へ更新します。
- `Cargo.lock`: `wayland-scanner` を 0.31.10 から 0.31.11、`quick-xml` を 0.39.2 から 0.41.0 へ更新します。
- `llmlb/tests/contract/endpoints_contract_extended_test.rs`: `..` と重複していた `admin_key: _` を除去し、Rust 1.97 の `clippy::unneeded_wildcard_pattern` を解消します。

## Testing

- [x] `cargo audit` — exit 0、vulnerabilities 0
- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — exit 0
- [x] `cargo test -- --test-threads=1` — 全 suite exit 0
- [x] `cargo test -p llmlb --test contract_tests endpoints_contract_extended_test::test_viewer_cannot_create_endpoint -- --exact` — 1 passed
- [x] `make quality-checks` — exit 0
- [x] `bash scripts/checks/check-commits.sh --from origin/develop --to HEAD` — 2 commits、0 problems
- [ ] post-fix canonical verification — 既存 record `vrr-f78dda1f17a441bc928b09fbdda690d0` は初回 HEAD の PASS。completed execution は immutable のため、post-fix HEAD では fresh linked-owner execution が必要
- [ ] GitHub CI — push `eebe72dd` の checks 実行中

## PR Readiness

- State: Draft
- Releaseable slice: yes — patched dependency 3 件と CI 互換性の機械的なテスト修正だけです
- Known blockers: post-fix HEAD の fresh canonical verification と GitHub CI 完了
- Remaining acceptance: canonical verification PASS 後の Ready 再昇格

## Closing Issues

- Closes #702

## Related Issues / Links

- #630
- #689

## Checklist

- [x] Tests added/updated (既存契約テストを Rust 1.97 lint に適合。依存更新は既存 `cargo audit` gate で RED/GREEN を確認)
- [x] Lint/format passed (`cargo clippy --all-targets --all-features`、`cargo fmt`)
- [x] Documentation updated (N/A: user-facing change なし。advisory 影響調査は #702 コメントに記録)
- [x] Migration/backfill plan included (N/A: schema/data change なし)
- [x] CHANGELOG impact considered (breaking change なし)

## Context

- `RUSTSEC-2026-0204` は criterion→rayon 経由の dev-only dependency です。
- `RUSTSEC-2026-0195` / `RUSTSEC-2026-0194` は synthetic な all-target graph 上の wayland scanner 経路で、各 concrete target の llmlb runtime からは到達不能ですが、patched crate へ更新して audit gate 自体を解消します。
- PR #689 は対象 crate を更新しないため、本 PR と重複しません。
- 初回 CI の `Rust Format & Clippy` failure は Rust 1.97 で既存テストに発生した新 lint であり、`origin/develop` にも存在する行でした。#625 の既存運用に従い、本 PR 内で最小の機械的修正を追加しました。

## Notes

- User Verification Result: n/a — user-facing runtime surface は変更せず、acceptance は `cargo audit`、dependency graph、Rust tests により自動検証可能です。
- 既存 working-tree 変更の `.codex/hooks.json` と `.gitattributes` は本 PR に含めていません。