### PR TITLE
fix(models): align official model catalog mappings

### DIFF
--- a/docs/model-catalog-policy.md
+++ b/docs/model-catalog-policy.md
@@ -14,13 +14,14 @@
 ルール:
 
 - canonical 名は HuggingFace 上で**実在するリポジトリ ID** を採用する（例:
-  `zai-org/glm-4.7-flash`、`openai/gpt-oss-20b`）。組織名が変わったモデルでは、
+  `zai-org/GLM-4.7-Flash`、`openai/gpt-oss-20b`）。組織名が変わったモデルでは、
   旧 org の表記を alias として残す（例: `THUDM/glm-4.7-flash` → alias）。
 - alias 名は **各エンドポイントタイプ固有の命名形式** に従う。
-  - Ollama: `family:tag`（例: `gpt-oss:20b`、`gemma4`）
+  - Ollama: `family:tag`（例: `gpt-oss:20b`、`gemma4:e4b`）
   - LM Studio: HuggingFace 形式（例: `openai/gpt-oss-20b`）
-- `:latest` のような **可変タグは alias に含めない**。世代交代でルックアップ先が
-  ねじれて、後方互換性を壊すため（例: `gemma4:latest` を撤廃）。
+- 新規 mapping では `:latest` のような **可変タグを原則登録しない**。Issue #643 の
+  Gemma 4 mapping には `gemma4:latest` を登録せず、SKU 固定タグを使う。一方、
+  Qwen / GLM / Nomic 等の既存 `:latest` alias は後方互換性のため残り得る。
 - 量子化サフィックス（`:Q4_K_M` など）は現状 ID に同居しているケースがあるが、
   正規化方針は別 SPEC で扱う（後述「量子化サフィックス方針」）。
 
@@ -47,22 +48,52 @@
 モデルの context length のみを登録する。バリエーションごとに異なる値が公称される
 モデル（量子化バリエーションで差がある等）は登録しない。
 
+Issue #643 で確認した fallback 値は次のとおり。
+
+| canonical | context length (tokens) |
+|---|---:|
+| `google/gemma-4-E2B-it` | 131072 |
+| `google/gemma-4-E4B-it` | 131072 |
+| `google/gemma-4-26B-A4B` | 262144 |
+| `google/gemma-4-26B-A4B-it` | 262144 |
+| `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` | 1048576 |
+| `nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16` | 262144 |
+| `Qwen/Qwen3-Coder-Next` | 262144 |
+| `zai-org/GLM-4.7-Flash` | 202752 |
+
+Nemotron 30B の 1048576 はモデルカードの公称最大 1M tokens であり、標準設定の値と
+異なる場合がある。実際の応答では前述のとおりエンドポイント申告値を優先する。
+
 新しいモデルを追加する際は出典（HF README / 公式リリースノート等）を PR 説明に
 記載する。
 
-## SKU 命名と派生バリエーション（G-2）
+## 検証済み SKU と派生バリエーション（G-1 / G-2 / G-5 / C-3）
 
 ggml-org のように community 配布版のリポジトリは、独自 SKU 接頭辞（`E2B`、`E4B`
-等）を付ける場合がある。これらは公式の SKU と区別される派生で、自動的な canonical
-集約はしない方針。必要なら個別に `BUILTIN_MAPPINGS` に登録する。
+等）を付ける場合がある。Issue #643 では一次情報と照合し、同一 SKU の GGUF
+再配布を次の official canonical へ明示的に集約した。サイズ違い、および base と
+instruction-tuned（`-it`）は別 SKU として扱う。
 
-例:
+| official canonical | 検証済みの対応・備考 |
+|---|---|
+| `google/gemma-4-E2B-it` | `ggml-org/gemma-4-E2B-it-GGUF` |
+| `google/gemma-4-E4B-it` | `ggml-org/gemma-4-E4B-it-GGUF` |
+| `google/gemma-4-26B-A4B` | Google 公式 base。対応する Ollama alias は割り当てない |
+| `google/gemma-4-26B-A4B-it` | `ggml-org/gemma-4-26B-A4B-it-GGUF` |
+| `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` | NVIDIA 公式 30B-A3B BF16 |
+| `nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16` | NVIDIA 公式 4B BF16 |
+| `Qwen/Qwen3-Coder-Next` | Qwen 公式 |
+| `zai-org/GLM-4.7-Flash` | Z.ai 公式。旧 `THUDM/glm-4.7-flash` は alias |
 
-- `ggml-org/gemma-4-E2B-it-GGUF`: ggml-org community エッジ派生（仮）
-- `google/gemma-4-26b-a4b`: Google 公式の MoE 版（実在性は別途確認）
+Gemma 4 の Ollama runtime 名は、SKU を一意にする固定タグだけを利用する。
 
-派生バリエーションは「同じ世代の別 SKU」として扱う。利用者には UI/ドキュメントで
-派生関係を明示する（dashboard 側の表示改善は別 SPEC）。
+- E2B instruction-tuned: `gemma4:e2b`
+- E4B instruction-tuned: outbound は固定タグ `gemma4:e4b` を優先する。既存の
+  bare `gemma4` は互換入力専用の legacy alias として受理する
+- 26B instruction-tuned: `gemma4:26b`
+- 26B base: Ollama alias なし
+
+`gemma4:latest` は参照先が将来変わり得るため、alias に含めない。
 
 ## 量子化サフィックス方針（G-3、暫定実装済み）
 
@@ -98,7 +129,9 @@ ggml-org のように community 配布版のリポジトリは、独自 SKU 接�
 
 「`id` を量子化なしへ正規化し、エンドポイントへのルーティング時に `quantization`
 を別経路で扱う」構造的分離はクライアント・dashboard・OpenAI 互換契約への影響が
-大きいため、この PR では扱わず別 SPEC（要 Issue 起票）で扱う。
+大きい。SPEC #575 US-029 では requestable な detail ID を維持し、canonical と
+variant の集約情報を別に提供する互換方針を採用したため、G-3-struct の破壊的な ID
+正規化案は superseded とする。
 
 ## 異常検知ログ（C-defensive）
 
@@ -114,14 +147,16 @@ ggml-org のように community 配布版のリポジトリは、独自 SKU 接�
 ほぼ常に `Registered` / `null` だが、UI 連動のため API レスポンスからは削除しない。
 状態管理を実装するか、フィールドそのものを廃止するかは別 SPEC で扱う。
 
-## 別 SPEC へ送る項目（このブランチでは扱わない）
+## Issue #643 の対応状況と残課題
 
-- B-4: `lifecycle_status` / `download_progress` の挙動見直し（UI 連動の影響範囲が広い）
-- G-1: ggml-org gemma-4-E2B/E4B の canonical 追加（Gemma 4 系 SKU の実在性確認 G-5 が前提。本書時点では self-canonical fallback で `canonical_name` に id 自身が入る暫定動作）
-- G-3 構造分離: `id` から量子化部分を除去し別経路でルーティングする破壊的変更（本書時点では `quantization` フィールド追加で情報の別出しまで実施）
-- G-5: Gemma 4 SKU 実在性の事実確認（外部リソース照合）
-- C-1 / C-2 / G-6: 単一エンドポイントの大量モデル誤申告の根本対応（エンドポイント側設定。本書時点では sync_models() の警告ログで早期検知のみ）
-- C-3: モデル名妥当性の事実確認（外部リソース照合）
+- G-1 / G-5 / C-3: Issue #643 で公式モデル ID、派生関係、runtime alias、context
+  fallback を一次情報と照合し、`BUILTIN_MAPPINGS` と本書へ反映済み。
+- G-3-struct: SPEC #575 US-029 の互換方針により superseded。requestable な `id` は
+  維持し、canonical / variant 情報で集約する。
+- B-4: `lifecycle_status` / `download_progress` は UI/API のプロダクト判断が必要なため、
+  lifecycle 状態管理の実装またはフィールド廃止を別 owner/decision として扱う。
+- C-1 / C-2 / G-6: 単一エンドポイントの大量モデル誤申告は operator / endpoint 側の
+  責務として扱う。llmlb 側は `sync_models()` の警告ログで早期検知する。
 
 ## 関連リンク
 

--- a/llmlb/src/models/mapping.rs
+++ b/llmlb/src/models/mapping.rs
@@ -1100,46 +1100,101 @@ mod tests {
     }
 
     #[test]
-    fn test_gemma4_ollama_resolves_to_canonical() {
-        // `gemma4:latest` は撤廃済み（将来世代の登場で意味がねじれるため）。
-        let removed = resolve_canonical("gemma4:latest", &EndpointType::Ollama);
-        assert_eq!(removed, None);
+    fn test_issue_643_gemma4_e2b_ollama_forwarding_uses_specific_tag() {
+        let canonical = "google/gemma-4-E2B-it";
 
-        // 具体タグ `gemma4` は引き続き alias として解決される。
-        let result = resolve_canonical("gemma4", &EndpointType::Ollama);
-        assert_eq!(result, Some("google/gemma-4-26B-A4B"));
+        assert_eq!(
+            resolve_engine_name(canonical, &EndpointType::Ollama),
+            Some("gemma4:e2b")
+        );
+        assert_eq!(
+            resolve_canonical("gemma4:e2b", &EndpointType::Ollama),
+            Some(canonical)
+        );
     }
 
     #[test]
-    fn test_gemma4_lm_studio_resolves_to_canonical() {
-        let result = resolve_canonical("google/gemma-4-26b-a4b", &EndpointType::LmStudio);
-        assert_eq!(result, Some("google/gemma-4-26B-A4B"));
+    fn test_issue_643_gemma4_e4b_ollama_forwarding_prefers_specific_tag() {
+        let canonical = "google/gemma-4-E4B-it";
+
+        assert_eq!(
+            resolve_engine_name(canonical, &EndpointType::Ollama),
+            Some("gemma4:e4b")
+        );
+        for alias in ["gemma4", "gemma4:e4b"] {
+            assert_eq!(
+                resolve_canonical(alias, &EndpointType::Ollama),
+                Some(canonical),
+                "failed for {alias}"
+            );
+        }
+        assert_eq!(
+            resolve_canonical("gemma4:latest", &EndpointType::Ollama),
+            None
+        );
     }
 
     #[test]
-    fn test_gemma4_engine_name_resolution() {
-        // `:latest` 撤廃により Ollama 側の優先 alias は具体タグ `gemma4`
-        let ollama = resolve_engine_name("google/gemma-4-26B-A4B", &EndpointType::Ollama);
-        assert_eq!(ollama, Some("gemma4"));
+    fn test_issue_643_gemma4_26b_it_ollama_forwarding_uses_specific_tag() {
+        let canonical = "google/gemma-4-26B-A4B-it";
 
-        let lms = resolve_engine_name("google/gemma-4-26B-A4B", &EndpointType::LmStudio);
-        assert_eq!(lms, Some("google/gemma-4-26b-a4b"));
+        assert_eq!(
+            resolve_canonical("gemma4:26b", &EndpointType::Ollama),
+            Some(canonical)
+        );
+        assert_eq!(
+            resolve_engine_name(canonical, &EndpointType::Ollama),
+            Some("gemma4:26b")
+        );
     }
 
     #[test]
-    fn test_issue_643_gemma4_e2b_and_e4b_gguf_aliases_resolve_distinct_official_canonicals() {
-        let e2b = resolve_canonical("ggml-org/gemma-4-E2B-it-GGUF", &EndpointType::LmStudio);
-        let e4b = resolve_canonical("ggml-org/gemma-4-E4B-it-GGUF", &EndpointType::LmStudio);
+    fn test_issue_643_gemma4_e2b_and_e4b_lm_studio_aliases_stay_distinct() {
+        let e2b = "google/gemma-4-E2B-it";
+        let e4b = "google/gemma-4-E4B-it";
 
-        assert_eq!(e2b, Some("google/gemma-4-E2B-it"));
-        assert_eq!(e4b, Some("google/gemma-4-E4B-it"));
+        for alias in ["google/gemma-4-e2b-it", "ggml-org/gemma-4-E2B-it-GGUF"] {
+            assert_eq!(
+                resolve_canonical(alias, &EndpointType::LmStudio),
+                Some(e2b),
+                "failed for {alias}"
+            );
+        }
+        for alias in ["google/gemma-4-e4b-it", "ggml-org/gemma-4-E4B-it-GGUF"] {
+            assert_eq!(
+                resolve_canonical(alias, &EndpointType::LmStudio),
+                Some(e4b),
+                "failed for {alias}"
+            );
+        }
     }
 
     #[test]
-    fn test_issue_643_gemma4_26b_preserves_official_canonical() {
-        let result = resolve_canonical("google/gemma-4-26B-A4B", &EndpointType::LmStudio);
+    fn test_issue_643_gemma4_26b_base_and_it_lm_studio_aliases_do_not_cross() {
+        let base = "google/gemma-4-26B-A4B";
+        let instruct = "google/gemma-4-26B-A4B-it";
 
-        assert_eq!(result, Some("google/gemma-4-26B-A4B"));
+        assert!(resolve_engine_names(base, &EndpointType::Ollama).is_empty());
+        assert_eq!(
+            resolve_canonical("google/gemma-4-26b-a4b", &EndpointType::LmStudio),
+            Some(base)
+        );
+        assert_eq!(
+            resolve_canonical("google/gemma-4-26b-a4b-it", &EndpointType::LmStudio),
+            Some(instruct)
+        );
+        assert_eq!(
+            resolve_canonical("ggml-org/gemma-4-26B-A4B-it-GGUF", &EndpointType::LmStudio),
+            Some(instruct)
+        );
+        assert_eq!(
+            resolve_engine_name(base, &EndpointType::LmStudio),
+            Some("google/gemma-4-26b-a4b")
+        );
+        assert_eq!(
+            resolve_engine_name(instruct, &EndpointType::LmStudio),
+            Some("google/gemma-4-26b-a4b-it")
+        );
     }
 
     #[test]
@@ -1288,7 +1343,6 @@ mod tests {
             known_max_tokens("Qwen/Qwen3-Coder-30B-A3B-Instruct"),
             Some(262_144)
         );
-        assert_eq!(known_max_tokens("zai-org/GLM-4.7-Flash"), Some(131_072));
         assert_eq!(
             known_max_tokens("nomic-ai/nomic-embed-text-v1.5"),
             Some(8_192)
@@ -1297,9 +1351,13 @@ mod tests {
 
     #[test]
     fn test_issue_643_known_max_tokens_gemma4_official_canonicals() {
+        let instruct_26b = "google/gemma-4-26B-A4B-it";
+
         assert_eq!(known_max_tokens("google/gemma-4-E2B-it"), Some(131_072));
         assert_eq!(known_max_tokens("google/gemma-4-E4B-it"), Some(131_072));
         assert_eq!(known_max_tokens("google/gemma-4-26B-A4B"), Some(262_144));
+        assert_eq!(known_max_tokens(instruct_26b), Some(262_144));
+        assert_eq!(resolve_max_tokens(instruct_26b, None), Some(262_144));
     }
 
     #[test]
@@ -1321,7 +1379,10 @@ mod tests {
 
     #[test]
     fn test_issue_643_known_max_tokens_glm_flash_official_canonical() {
-        assert_eq!(known_max_tokens("zai-org/GLM-4.7-Flash"), Some(131_072));
+        let canonical = "zai-org/GLM-4.7-Flash";
+
+        assert_eq!(known_max_tokens(canonical), Some(202_752));
+        assert_eq!(resolve_max_tokens(canonical, None), Some(202_752));
     }
 
     #[test]

--- a/llmlb/src/models/mapping.rs
+++ b/llmlb/src/models/mapping.rs
@@ -191,7 +191,7 @@ pub static BUILTIN_MAPPINGS: &[ModelMapping] = &[
         ],
     },
     ModelMapping {
-        canonical: "nvidia/Nemotron-3-Nano",
+        canonical: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
         aliases: &[
             EngineAlias {
                 engine: EndpointType::Ollama,
@@ -201,11 +201,14 @@ pub static BUILTIN_MAPPINGS: &[ModelMapping] = &[
                 engine: EndpointType::LmStudio,
                 name: "nvidia/nemotron-3-nano",
             },
-            EngineAlias {
-                engine: EndpointType::LmStudio,
-                name: "nvidia/nemotron-3-nano-4b",
-            },
         ],
+    },
+    ModelMapping {
+        canonical: "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
+        aliases: &[EngineAlias {
+            engine: EndpointType::LmStudio,
+            name: "nvidia/nemotron-3-nano-4b",
+        }],
     },
     ModelMapping {
         canonical: "Qwen/Qwen2.5-14B-Instruct-AWQ",
@@ -245,10 +248,10 @@ pub static BUILTIN_MAPPINGS: &[ModelMapping] = &[
             },
         ],
     },
-    // GLM-4.7-Flash: HuggingFace 上の現行リポジトリは `zai-org/glm-4.7-flash`（旧 THUDM）。
+    // GLM-4.7-Flash: HuggingFace 上の現行リポジトリは `zai-org/GLM-4.7-Flash`（旧 THUDM）。
     // canonical は実在するリポジトリ ID に合わせ、`THUDM/...` は alias として残す。
     ModelMapping {
-        canonical: "zai-org/glm-4.7-flash",
+        canonical: "zai-org/GLM-4.7-Flash",
         aliases: &[
             EngineAlias {
                 engine: EndpointType::Ollama,
@@ -260,14 +263,44 @@ pub static BUILTIN_MAPPINGS: &[ModelMapping] = &[
             },
             EngineAlias {
                 engine: EndpointType::LmStudio,
+                name: "zai-org/glm-4.7-flash",
+            },
+            EngineAlias {
+                engine: EndpointType::LmStudio,
                 name: "THUDM/glm-4.7-flash",
+            },
+        ],
+    },
+    ModelMapping {
+        canonical: "google/gemma-4-E2B-it",
+        aliases: &[
+            EngineAlias {
+                engine: EndpointType::LmStudio,
+                name: "google/gemma-4-e2b-it",
+            },
+            EngineAlias {
+                engine: EndpointType::LmStudio,
+                name: "ggml-org/gemma-4-E2B-it-GGUF",
+            },
+        ],
+    },
+    ModelMapping {
+        canonical: "google/gemma-4-E4B-it",
+        aliases: &[
+            EngineAlias {
+                engine: EndpointType::LmStudio,
+                name: "google/gemma-4-e4b-it",
+            },
+            EngineAlias {
+                engine: EndpointType::LmStudio,
+                name: "ggml-org/gemma-4-E4B-it-GGUF",
             },
         ],
     },
     // Gemma 4 (26B-A4B): `:latest` は将来世代の登場で意味がねじれる反パターンのため alias から外す。
     // 具体タグ `gemma4` のみを Ollama alias として保持。
     ModelMapping {
-        canonical: "google/gemma-4-26b-a4b",
+        canonical: "google/gemma-4-26B-A4B",
         aliases: &[
             EngineAlias {
                 engine: EndpointType::Ollama,
@@ -707,16 +740,20 @@ const KNOWN_CONTEXT_LENGTHS: &[(&str, u32)] = &[
     ("openai/gpt-oss-120b", 131_072),
     // Qwen
     ("Qwen/Qwen3-Coder-30B-A3B-Instruct", 262_144),
+    ("Qwen/Qwen3-Coder-Next", 262_144),
     ("Qwen/Qwen3.5-35B-A3B", 262_144),
     ("Qwen/Qwen2.5-14B-Instruct-AWQ", 32_768),
     // Google Gemma
     ("google/gemma-3-27b-it", 131_072),
-    ("google/gemma-4-26b-a4b", 131_072),
+    ("google/gemma-4-E2B-it", 131_072),
+    ("google/gemma-4-E4B-it", 131_072),
+    ("google/gemma-4-26B-A4B", 262_144),
     // GLM
-    ("zai-org/glm-4.7-flash", 131_072),
+    ("zai-org/GLM-4.7-Flash", 131_072),
     // Nvidia Nemotron
     ("nvidia/nemotron-3-super-120b-a12b", 131_072),
-    ("nvidia/Nemotron-3-Nano", 131_072),
+    ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", 1_048_576),
+    ("nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16", 262_144),
     // Meta Llama
     ("meta-llama/Llama-3.3-70B-Instruct", 131_072),
     // Embeddings

--- a/llmlb/src/models/mapping.rs
+++ b/llmlb/src/models/mapping.rs
@@ -275,6 +275,10 @@ pub static BUILTIN_MAPPINGS: &[ModelMapping] = &[
         canonical: "google/gemma-4-E2B-it",
         aliases: &[
             EngineAlias {
+                engine: EndpointType::Ollama,
+                name: "gemma4:e2b",
+            },
+            EngineAlias {
                 engine: EndpointType::LmStudio,
                 name: "google/gemma-4-e2b-it",
             },
@@ -288,6 +292,14 @@ pub static BUILTIN_MAPPINGS: &[ModelMapping] = &[
         canonical: "google/gemma-4-E4B-it",
         aliases: &[
             EngineAlias {
+                engine: EndpointType::Ollama,
+                name: "gemma4:e4b",
+            },
+            EngineAlias {
+                engine: EndpointType::Ollama,
+                name: "gemma4",
+            },
+            EngineAlias {
                 engine: EndpointType::LmStudio,
                 name: "google/gemma-4-e4b-it",
             },
@@ -297,18 +309,29 @@ pub static BUILTIN_MAPPINGS: &[ModelMapping] = &[
             },
         ],
     },
-    // Gemma 4 (26B-A4B): `:latest` は将来世代の登場で意味がねじれる反パターンのため alias から外す。
-    // 具体タグ `gemma4` のみを Ollama alias として保持。
+    // Gemma 4: `:latest` は将来世代の登場で意味がねじれる反パターンのため alias から外す。
+    // base と instruction-tuned は別 canonical とし、固定 Ollama tag は instruction-tuned にだけ割り当てる。
     ModelMapping {
         canonical: "google/gemma-4-26B-A4B",
+        aliases: &[EngineAlias {
+            engine: EndpointType::LmStudio,
+            name: "google/gemma-4-26b-a4b",
+        }],
+    },
+    ModelMapping {
+        canonical: "google/gemma-4-26B-A4B-it",
         aliases: &[
             EngineAlias {
                 engine: EndpointType::Ollama,
-                name: "gemma4",
+                name: "gemma4:26b",
             },
             EngineAlias {
                 engine: EndpointType::LmStudio,
-                name: "google/gemma-4-26b-a4b",
+                name: "google/gemma-4-26b-a4b-it",
+            },
+            EngineAlias {
+                engine: EndpointType::LmStudio,
+                name: "ggml-org/gemma-4-26B-A4B-it-GGUF",
             },
         ],
     },
@@ -748,8 +771,9 @@ const KNOWN_CONTEXT_LENGTHS: &[(&str, u32)] = &[
     ("google/gemma-4-E2B-it", 131_072),
     ("google/gemma-4-E4B-it", 131_072),
     ("google/gemma-4-26B-A4B", 262_144),
+    ("google/gemma-4-26B-A4B-it", 262_144),
     // GLM
-    ("zai-org/GLM-4.7-Flash", 131_072),
+    ("zai-org/GLM-4.7-Flash", 202_752),
     // Nvidia Nemotron
     ("nvidia/nemotron-3-super-120b-a12b", 131_072),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", 1_048_576),

--- a/llmlb/src/models/mapping.rs
+++ b/llmlb/src/models/mapping.rs
@@ -1591,29 +1591,32 @@ mod tests {
     #[test]
     fn test_heuristic_merges_redistributor_into_explicit_first_party() {
         // Codex review 回帰: BUILTIN 由来で explicit canonical を持つ一次配布元モデル
-        // （google/gemma-4-26b-a4b）に、explicit canonical を持たない再配布 GGUF が
+        // （google/gemma-4-26B-A4B-it）に、explicit canonical を持たない再配布 GGUF が
         // 同一 identity として集約されること（Pass 1 の first-party もアンカーになる）。
         let models = vec![
-            ("gemma4", Some("google/gemma-4-26b-a4b")), // Ollama alias (Pass1)
-            ("google/gemma-4-26b-a4b", Some("google/gemma-4-26b-a4b")), // self explicit (Pass1)
-            ("ggml-org/gemma-4-26B-A4B-GGUF", None),    // redistributor (Pass2)
+            ("gemma4:26b", Some("google/gemma-4-26B-A4B-it")), // Ollama alias (Pass1)
+            (
+                "google/gemma-4-26B-A4B-it",
+                Some("google/gemma-4-26B-A4B-it"),
+            ), // self explicit (Pass1)
+            ("ggml-org/gemma-4-26B-A4B-it-GGUF", None),        // redistributor (Pass2)
         ];
         let res = build_canonical_maps(models.into_iter());
         assert_eq!(
-            res.canonical_for("ggml-org/gemma-4-26B-A4B-GGUF"),
-            "google/gemma-4-26b-a4b"
+            res.canonical_for("ggml-org/gemma-4-26B-A4B-it-GGUF"),
+            "google/gemma-4-26B-A4B-it"
         );
-        let aliases = res.aliases_for("google/gemma-4-26b-a4b");
-        assert!(aliases.contains(&"ggml-org/gemma-4-26B-A4B-GGUF".to_string()));
-        assert!(aliases.contains(&"gemma4".to_string()));
+        let aliases = res.aliases_for("google/gemma-4-26B-A4B-it");
+        assert!(aliases.contains(&"ggml-org/gemma-4-26B-A4B-it-GGUF".to_string()));
+        assert!(aliases.contains(&"gemma4:26b".to_string()));
     }
 
     #[test]
     fn test_heuristic_no_anchor_when_first_party_is_redistributor_only() {
         // 一次配布元が explicit でも self でも存在しない場合はマージしない。
         let models = vec![
-            ("gemma4", Some("google/gemma-4-26b-a4b")), // 別 identity (base/26b-a4b)
-            ("bartowski/qwen3-99b-it-GGUF", None),      // 一次配布元(Qwen)未観測の re-dist
+            ("gemma4:26b", Some("google/gemma-4-26B-A4B-it")), // 別 identity (26B-it)
+            ("bartowski/qwen3-99b-it-GGUF", None),             // 一次配布元(Qwen)未観測の re-dist
         ];
         let res = build_canonical_maps(models.into_iter());
         assert_eq!(

--- a/llmlb/src/models/mapping.rs
+++ b/llmlb/src/models/mapping.rs
@@ -970,17 +970,6 @@ mod tests {
     }
 
     #[test]
-    fn test_glm47_mapping() {
-        // canonical は zai-org に統一（HF 上の現行リポジトリ）
-        let result = resolve_canonical("zai-org/glm-4.7-flash", &EndpointType::LmStudio);
-        assert_eq!(result, Some("zai-org/glm-4.7-flash"));
-
-        // 旧 THUDM 名は alias として canonical に解決される
-        let legacy = resolve_canonical("THUDM/glm-4.7-flash", &EndpointType::LmStudio);
-        assert_eq!(legacy, Some("zai-org/glm-4.7-flash"));
-    }
-
-    #[test]
     fn test_nomic_embedding_mapping() {
         let result = resolve_canonical(
             "text-embedding-nomic-embed-text-v1.5",
@@ -1017,12 +1006,12 @@ mod tests {
     }
 
     #[test]
-    fn test_nvidia_nemotron_nano_mapping() {
+    fn test_issue_643_nemotron_nano_30b_aliases_resolve_official_canonical() {
         let ollama = resolve_canonical("nemotron-3-nano:30b", &EndpointType::Ollama);
-        assert_eq!(ollama, Some("nvidia/Nemotron-3-Nano"));
+        assert_eq!(ollama, Some("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"));
 
-        let result = resolve_canonical("nvidia/nemotron-3-nano", &EndpointType::LmStudio);
-        assert_eq!(result, Some("nvidia/Nemotron-3-Nano"));
+        let legacy = resolve_canonical("nvidia/nemotron-3-nano", &EndpointType::LmStudio);
+        assert_eq!(legacy, Some("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"));
     }
 
     #[test]
@@ -1038,16 +1027,16 @@ mod tests {
     }
 
     #[test]
-    fn test_glm_flash_mapping() {
+    fn test_issue_643_glm_flash_aliases_resolve_official_canonical() {
         let ollama = resolve_canonical("glm-4.7-flash:latest", &EndpointType::Ollama);
-        assert_eq!(ollama, Some("zai-org/glm-4.7-flash"));
+        assert_eq!(ollama, Some("zai-org/GLM-4.7-Flash"));
 
-        let result = resolve_canonical("zai-org/glm-4.7-flash", &EndpointType::LmStudio);
-        assert_eq!(result, Some("zai-org/glm-4.7-flash"));
+        let lowercase = resolve_canonical("zai-org/glm-4.7-flash", &EndpointType::LmStudio);
+        assert_eq!(lowercase, Some("zai-org/GLM-4.7-Flash"));
 
         // legacy THUDM/... も alias 経由で canonical に解決される
         let legacy = resolve_canonical("THUDM/glm-4.7-flash", &EndpointType::LmStudio);
-        assert_eq!(legacy, Some("zai-org/glm-4.7-flash"));
+        assert_eq!(legacy, Some("zai-org/GLM-4.7-Flash"));
     }
 
     #[test]
@@ -1081,29 +1070,52 @@ mod tests {
 
         // 具体タグ `gemma4` は引き続き alias として解決される。
         let result = resolve_canonical("gemma4", &EndpointType::Ollama);
-        assert_eq!(result, Some("google/gemma-4-26b-a4b"));
+        assert_eq!(result, Some("google/gemma-4-26B-A4B"));
     }
 
     #[test]
     fn test_gemma4_lm_studio_resolves_to_canonical() {
         let result = resolve_canonical("google/gemma-4-26b-a4b", &EndpointType::LmStudio);
-        assert_eq!(result, Some("google/gemma-4-26b-a4b"));
+        assert_eq!(result, Some("google/gemma-4-26B-A4B"));
     }
 
     #[test]
     fn test_gemma4_engine_name_resolution() {
         // `:latest` 撤廃により Ollama 側の優先 alias は具体タグ `gemma4`
-        let ollama = resolve_engine_name("google/gemma-4-26b-a4b", &EndpointType::Ollama);
+        let ollama = resolve_engine_name("google/gemma-4-26B-A4B", &EndpointType::Ollama);
         assert_eq!(ollama, Some("gemma4"));
 
-        let lms = resolve_engine_name("google/gemma-4-26b-a4b", &EndpointType::LmStudio);
+        let lms = resolve_engine_name("google/gemma-4-26B-A4B", &EndpointType::LmStudio);
         assert_eq!(lms, Some("google/gemma-4-26b-a4b"));
     }
 
     #[test]
-    fn test_nemotron_nano_4b_alias_resolves() {
+    fn test_issue_643_gemma4_e2b_and_e4b_gguf_aliases_resolve_distinct_official_canonicals() {
+        let e2b = resolve_canonical("ggml-org/gemma-4-E2B-it-GGUF", &EndpointType::LmStudio);
+        let e4b = resolve_canonical("ggml-org/gemma-4-E4B-it-GGUF", &EndpointType::LmStudio);
+
+        assert_eq!(e2b, Some("google/gemma-4-E2B-it"));
+        assert_eq!(e4b, Some("google/gemma-4-E4B-it"));
+    }
+
+    #[test]
+    fn test_issue_643_gemma4_26b_preserves_official_canonical() {
+        let result = resolve_canonical("google/gemma-4-26B-A4B", &EndpointType::LmStudio);
+
+        assert_eq!(result, Some("google/gemma-4-26B-A4B"));
+    }
+
+    #[test]
+    fn test_issue_643_qwen3_coder_next_preserves_official_canonical() {
+        let result = resolve_canonical("Qwen/Qwen3-Coder-Next", &EndpointType::LmStudio);
+
+        assert_eq!(result, Some("Qwen/Qwen3-Coder-Next"));
+    }
+
+    #[test]
+    fn test_issue_643_nemotron_nano_4b_alias_resolves_official_canonical() {
         let result = resolve_canonical("nvidia/nemotron-3-nano-4b", &EndpointType::LmStudio);
-        assert_eq!(result, Some("nvidia/Nemotron-3-Nano"));
+        assert_eq!(result, Some("nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16"));
     }
 
     #[test]
@@ -1239,11 +1251,40 @@ mod tests {
             known_max_tokens("Qwen/Qwen3-Coder-30B-A3B-Instruct"),
             Some(262_144)
         );
-        assert_eq!(known_max_tokens("zai-org/glm-4.7-flash"), Some(131_072));
+        assert_eq!(known_max_tokens("zai-org/GLM-4.7-Flash"), Some(131_072));
         assert_eq!(
             known_max_tokens("nomic-ai/nomic-embed-text-v1.5"),
             Some(8_192)
         );
+    }
+
+    #[test]
+    fn test_issue_643_known_max_tokens_gemma4_official_canonicals() {
+        assert_eq!(known_max_tokens("google/gemma-4-E2B-it"), Some(131_072));
+        assert_eq!(known_max_tokens("google/gemma-4-E4B-it"), Some(131_072));
+        assert_eq!(known_max_tokens("google/gemma-4-26B-A4B"), Some(262_144));
+    }
+
+    #[test]
+    fn test_issue_643_known_max_tokens_nemotron_nano_official_canonicals() {
+        assert_eq!(
+            known_max_tokens("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"),
+            Some(1_048_576)
+        );
+        assert_eq!(
+            known_max_tokens("nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16"),
+            Some(262_144)
+        );
+    }
+
+    #[test]
+    fn test_issue_643_known_max_tokens_qwen3_coder_next_official_canonical() {
+        assert_eq!(known_max_tokens("Qwen/Qwen3-Coder-Next"), Some(262_144));
+    }
+
+    #[test]
+    fn test_issue_643_known_max_tokens_glm_flash_official_canonical() {
+        assert_eq!(known_max_tokens("zai-org/GLM-4.7-Flash"), Some(131_072));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- 公式配布元の canonical model ID と context fallback を一次情報へ揃え、`/v1/models` の誤集約を防ぎます。
- Gemma 4 E2B/E4B/26B base/26B-it と Nemotron 30B/4B を別 identity にし、runtime tag の誤転送を解消します。
- 検証済みの alias、context 値、残課題の owner 境界を model catalog policy に記録します。

## Changes

- `llmlb/src/models/mapping.rs`: Gemma、Nemotron、GLM、Qwen の canonical/alias/context table と回帰テストを更新しました。
- `docs/model-catalog-policy.md`: 公式 repository、Ollama forwarding tag、context fallback、Issue #643 の残課題分類を更新しました。

## Testing

- [x] `cargo test -p llmlb --lib issue_643 -- --test-threads=1` — 13/13 PASS
- [x] `cargo test -p llmlb --lib models::mapping -- --test-threads=1` — 77/77 PASS
- [x] `git diff --check origin/develop...HEAD` — PASS
- [x] `bash scripts/checks/check-commits.sh --from origin/develop --to HEAD` — 6/6 commits PASS
- [x] `make quality-checks` — PASS
- [x] Verification Run Record `vrr-6c3a0c84df774d1eb0099f862465a112` — 5/5 commands PASS

## PR Readiness

- State: Ready for review
- Releaseable slice: Yes — static mapping/context data とその tests/docs だけで、public API/DB schema を変更しません。
- Known blockers: None
- Remaining acceptance: None for this PR scope. B-4 と C-1/C-2/G-6 は Issue #643 で別 owner/decision として継続します。

## Closing Issues

- None

## Related Issues / Links

- #643
- #575 (US-029)

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated
- [x] Migration/backfill plan included — N/A: schema/data migration なし
- [x] CHANGELOG impact considered — N/A: public API の破壊的変更なし

## Context

- Issue #643 の G-1/G-5/C-3 は SPEC #575 US-029 の実装ギャップで、既存 table が SKU/tuning と runtime tag を混同していました。
- G-3-struct は US-029 の requestable detail ID 互換方針で superseded とし、lifecycle UI/API と operator endpoint over-reporting はこのPRに含めません。

## Risk / Impact

- **Affected areas**: model canonicalization、endpoint runtime name forwarding、endpoint が context を返さない場合の fallback
- **Rollback plan**: このPRを revert します。永続化変更や backfill はありません。

## Notes

- User verification は無人実行かつ非UIの business-logic/data-table 変更のため `skipped(unattended non-user-facing slice; automated coverage recorded)` としました。